### PR TITLE
misc: fix all clippy / fmt error in trunk as 05/06/2026

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,12 +58,12 @@ strip = true
 
 # Clippy lints configuration
 [lints.clippy]
-correctness = { level = "deny", priority = -1 }
-suspicious = { level = "deny", priority = -1 }
+correctness = { level = "deny", priority = -2 }
+suspicious = { level = "deny", priority = -2 }
 
-complexity = { level = "warn", priority = -1 }
-perf = { level = "warn", priority = -1 }
-style = { level = "warn", priority = -1 }
+complexity = { level = "warn", priority = -2 }
+perf = { level = "warn", priority = -2 }
+style = { level = "warn", priority = -2 }
 
 unwrap_used = { level = "warn", priority = -1 }
 expect_used = { level = "warn", priority = -1 }

--- a/crates/oxidui_style/src/number.rs
+++ b/crates/oxidui_style/src/number.rs
@@ -1,6 +1,3 @@
-use std::fmt::{Display, Formatter, Result};
-use std::hash::{Hash, Hasher};
-use std::ops::{Add, Mul, Neg, Sub};
 use std::{
     fmt::{self, Display, Formatter, Result},
     hash::{Hash, Hasher},
@@ -50,42 +47,31 @@ impl Int {
     pub const ONE: Self = Self(1);
     /// Zero constant.
     pub const ZERO: Self = Self(0);
-    /// One — useful for `order: 1`, `column-count: 1`, etc.
-    pub const ONE: Self = Self(1);
 
     /// Construct from a raw `i32`.
     pub const fn new(v: i32) -> Self {
         Self(v)
     }
-    /// Extract the underlying `i32`.
+
+    /// Extract inner value.
     pub const fn get(self) -> i32 {
         self.0
     }
-    /// Returns `true` if the value is zero.
+
     pub const fn is_zero(self) -> bool {
         self.0 == 0
     }
-    /// Returns `true` if the value is negative.
+
     pub const fn is_negative(self) -> bool {
         self.0 < 0
     }
-
-    /// Construct from raw `i32`.
-    pub const fn new(v: i32) -> Self { Self(v) }
-
-    /// Extract inner value.
-    pub const fn get(self) -> i32 { self.0 }
-
-    pub const fn is_zero(self) -> bool { self.0 == 0 }
-
-    pub const fn is_negative(self) -> bool { self.0 < 0 }
 
     /// Precise radix constructor (2–36).
     pub fn from_str_radix(
         s: &str,
         radix: u32,
     ) -> std::result::Result<Self, IntParseError> {
-        if (radix < 2) || (radix > 36) {
+        if !(2..=36).contains(&radix) {
             return Err(IntParseError::InvalidRadix);
         }
         i32::from_str_radix(s, radix)
@@ -94,16 +80,24 @@ impl Int {
     }
 
     /// Format as binary with `0b` prefix.
-    pub fn to_bin(self) -> String { format!("0b{:b}", self.0) }
+    pub fn to_bin(self) -> String {
+        format!("0b{:b}", self.0)
+    }
 
     /// Format as octal with `0o` prefix.
-    pub fn to_oct(self) -> String { format!("0o{:o}", self.0) }
+    pub fn to_oct(self) -> String {
+        format!("0o{:o}", self.0)
+    }
 
     /// Format as lowercase hex with `0x` prefix.
-    pub fn to_hex(self) -> String { format!("0x{:x}", self.0) }
+    pub fn to_hex(self) -> String {
+        format!("0x{:x}", self.0)
+    }
 
     /// Format as uppercase hex with `0X` prefix.
-    pub fn to_hex_upper(self) -> String { format!("0X{:X}", self.0) }
+    pub fn to_hex_upper(self) -> String {
+        format!("0X{:X}", self.0)
+    }
 }
 
 impl FromStr for Int {
@@ -136,30 +130,42 @@ impl FromStr for Int {
 }
 
 impl From<i32> for Int {
-    fn from(v: i32) -> Self { Self(v) }
+    fn from(v: i32) -> Self {
+        Self(v)
+    }
 }
 impl From<Int> for i32 {
-    fn from(v: Int) -> Self { v.0 }
+    fn from(v: Int) -> Self {
+        v.0
+    }
 }
 
 impl Display for Int {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result { write!(f, "{}", self.0) }
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 impl Add for Int {
     type Output = Self;
 
-    fn add(self, rhs: Self) -> Self { Self(self.0 + rhs.0) }
+    fn add(self, rhs: Self) -> Self {
+        Self(self.0 + rhs.0)
+    }
 }
 impl Sub for Int {
     type Output = Self;
 
-    fn sub(self, rhs: Self) -> Self { Self(self.0 - rhs.0) }
+    fn sub(self, rhs: Self) -> Self {
+        Self(self.0 - rhs.0)
+    }
 }
 impl Neg for Int {
     type Output = Self;
 
-    fn neg(self) -> Self { Self(-self.0) }
+    fn neg(self) -> Self {
+        Self(-self.0)
+    }
 }
 
 /// A CSS-like floating-point scalar value.
@@ -198,23 +204,33 @@ impl Float {
     pub const ZERO: Self = Self(0.0);
 
     /// Construct from a raw `f32`.
-    pub const fn new(v: f32) -> Self { Self(v) }
+    pub const fn new(v: f32) -> Self {
+        Self(v)
+    }
 
     /// Extract the underlying `f32`.
-    pub const fn get(self) -> f32 { self.0 }
+    pub const fn get(self) -> f32 {
+        self.0
+    }
 
     /// Clamp to `[0.0, 1.0]`.
     ///
     /// Useful for `opacity`, `flex-shrink`, or any unit-interval property.
-    pub fn clamp_unit(self) -> Self { Self(self.0.clamp(0.0, 1.0)) }
+    pub fn clamp_unit(self) -> Self {
+        Self(self.0.clamp(0.0, 1.0))
+    }
 
     /// Returns `true` if the value is exactly `0.0`.
-    pub fn is_zero(self) -> bool { self.0 == 0.0 }
+    pub fn is_zero(self) -> bool {
+        self.0 == 0.0
+    }
 }
 
 /// Bit-equality. See type-level docs for NaN rationale.
 impl PartialEq for Float {
-    fn eq(&self, other: &Self) -> bool { self.0.to_bits() == other.0.to_bits() }
+    fn eq(&self, other: &Self) -> bool {
+        self.0.to_bits() == other.0.to_bits()
+    }
 }
 
 /// Derived from bit-equality — see [`PartialEq`] impl.
@@ -222,7 +238,9 @@ impl Eq for Float {}
 
 /// Bit-pattern hash — consistent with the `PartialEq` implementation.
 impl Hash for Float {
-    fn hash<H: Hasher>(&self, state: &mut H) { self.0.to_bits().hash(state); }
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.to_bits().hash(state);
+    }
 }
 
 impl PartialOrd for Float {
@@ -232,23 +250,33 @@ impl PartialOrd for Float {
 }
 
 impl From<f32> for Float {
-    fn from(v: f32) -> Self { Self(v) }
+    fn from(v: f32) -> Self {
+        Self(v)
+    }
 }
 impl From<Float> for f32 {
-    fn from(v: Float) -> Self { v.0 }
+    fn from(v: Float) -> Self {
+        v.0
+    }
 }
 
 impl Display for Float {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result { write!(f, "{}", self.0) }
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 impl Add for Float {
     type Output = Self;
 
-    fn add(self, rhs: Self) -> Self { Self(self.0 + rhs.0) }
+    fn add(self, rhs: Self) -> Self {
+        Self(self.0 + rhs.0)
+    }
 }
 impl Mul for Float {
     type Output = Self;
 
-    fn mul(self, rhs: Self) -> Self { Self(self.0 * rhs.0) }
+    fn mul(self, rhs: Self) -> Self {
+        Self(self.0 * rhs.0)
+    }
 }

--- a/crates/oxidui_style/src/str.rs
+++ b/crates/oxidui_style/src/str.rs
@@ -32,26 +32,40 @@ impl Str {
     /// Construct from a `'static` str — zero allocation.
     ///
     /// Preferred for proc_macro output.
-    pub const fn from_static(s: &'static str) -> Self { Self(Cow::Borrowed(s)) }
+    pub const fn from_static(s: &'static str) -> Self {
+        Self(Cow::Borrowed(s))
+    }
 
     /// Construct from a runtime-owned `String` — heap-allocates.
-    pub fn from_string(s: String) -> Self { Self(Cow::Owned(s)) }
+    pub fn from_string(s: String) -> Self {
+        Self(Cow::Owned(s))
+    }
 
     /// Borrow the inner string slice.
-    pub fn as_str(&self) -> &str { &self.0 }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 
     /// Returns `true` if the string is empty.
-    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl From<&'static str> for Str {
-    fn from(s: &'static str) -> Self { Self::from_static(s) }
+    fn from(s: &'static str) -> Self {
+        Self::from_static(s)
+    }
 }
 impl From<String> for Str {
-    fn from(s: String) -> Self { Self::from_string(s) }
+    fn from(s: String) -> Self {
+        Self::from_string(s)
+    }
 }
 impl AsRef<str> for Str {
-    fn as_ref(&self) -> &str { self.as_str() }
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
 }
 
 impl std::fmt::Display for Str {

--- a/crates/oxidui_style/src/unit.rs
+++ b/crates/oxidui_style/src/unit.rs
@@ -33,7 +33,7 @@
 /// let flex = Unit::fill(1); // take 1 share of remaining space
 /// let auto = Unit::AUTO; // size to content
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum Unit {
     /// Absolute size in terminal character cells.
     ///
@@ -65,6 +65,7 @@ pub enum Unit {
     /// never emit `Unset` directly; the parser produces `None` at the
     /// `Style` field level instead. Exists for `Edges<Unit>` where a
     /// `Unit` must be present but is logically absent.
+    #[default]
     Unset,
 }
 
@@ -84,13 +85,19 @@ impl Unit {
     pub const ZERO: Self = Self::Cells(0);
 
     /// Absolute cell-count value.
-    pub const fn cells(n: i32) -> Self { Self::Cells(n) }
+    pub const fn cells(n: i32) -> Self {
+        Self::Cells(n)
+    }
 
     /// Percentage value (0–100).
-    pub const fn percent(n: u8) -> Self { Self::Percent(n) }
+    pub const fn percent(n: u8) -> Self {
+        Self::Percent(n)
+    }
 
     /// Proportional fill with the given weight.
-    pub const fn fill(w: u16) -> Self { Self::Fill(w) }
+    pub const fn fill(w: u16) -> Self {
+        Self::Fill(w)
+    }
 
     /// `true` if the value is concrete and calculable without layout context
     /// (i.e. `Cells` or `Percent`).
@@ -105,7 +112,9 @@ impl Unit {
     }
 
     /// `true` if the value is logically absent.
-    pub const fn is_unset(self) -> bool { matches!(self, Self::Unset) }
+    pub const fn is_unset(self) -> bool {
+        matches!(self, Self::Unset)
+    }
 
     /// Extract `Cells(n)` → `Some(n)`, anything else → `None`.
     pub const fn as_cells(self) -> Option<i32> {
@@ -122,8 +131,4 @@ impl Unit {
             _ => None,
         }
     }
-}
-
-impl Default for Unit {
-    fn default() -> Self { Self::Unset }
 }

--- a/crates/termoxide_reactive/src/effect.rs
+++ b/crates/termoxide_reactive/src/effect.rs
@@ -3,8 +3,7 @@
 //! An [`Effect`] is a closure that automatically re-executes whenever a
 //! signal it depends on changes.
 
-use reactive_graph::effect::Effect as InnerEffect;
-use reactive_graph::owner::LocalStorage;
+use reactive_graph::{effect::Effect as InnerEffect, owner::LocalStorage};
 
 /// Side-effect that re-executes when its dependencies change.
 ///
@@ -14,7 +13,7 @@ use reactive_graph::owner::LocalStorage;
 /// # Example
 ///
 /// ```no_run
-/// use termoxide_reactive::{Signal, Effect, runtime::with_owner};
+/// use termoxide_reactive::{Effect, Signal, runtime::with_owner};
 ///
 /// with_owner(|| {
 ///     let name = Signal::new(String::from("Alice"));
@@ -41,7 +40,5 @@ impl Effect {
         Self(InnerEffect::new(f))
     }
 
-    pub fn inner(&self) -> &InnerEffect<LocalStorage> {
-        &self.0
-    }
+    pub fn inner(&self) -> &InnerEffect<LocalStorage> { &self.0 }
 }

--- a/crates/termoxide_reactive/src/lib.rs
+++ b/crates/termoxide_reactive/src/lib.rs
@@ -5,14 +5,14 @@
 //!
 //! ## Overview of primitives
 //!
-//! | Type | Role |
+//! |Type|Role|
 //! |------|------|
-//! | [`Signal<T>`] | Mutable reactive state with automatic notifications |
-//! | [`Memo<T>`] | Derived value computed lazily, recomputed on dependency change |
-//! | [`Effect`] | Reactive side-effect re-run when dependencies change |
-//! | [`Resource<T>`] | Asynchronous loading integrated into the reactive graph |
-//! | [`Trigger`] | Manual trigger without an associated value |
-//! | [`StoredValue<T>`] | Non-reactive, owner-scoped `Copy` storage |
+//! |[`Signal<T>`]|Mutable reactive state with automatic notifications|
+//! |[`Memo<T>`]|Derived value computed lazily, recomputed on dependency change|
+//! |[`Effect`]|Reactive side-effect re-run when dependencies change|
+//! |[`Resource<T>`]|Asynchronous loading integrated into the reactive graph|
+//! |[`Trigger`]|Manual trigger without an associated value|
+//! |[`StoredValue<T>`]|Non-reactive, owner-scoped `Copy` storage|
 //!
 //! All handles ([`Signal`], [`Memo`], [`Trigger`], [`Resource`],
 //! [`StoredValue`]) storage is tied to the enclosing [`runtime::Owner`].
@@ -20,7 +20,13 @@
 //! ## Quickstart
 //!
 //! ```no_run
-//! use termoxide_reactive::{Signal, Memo, Effect, Trigger, runtime::with_owner};
+//! use termoxide_reactive::{
+//!     Effect,
+//!     Memo,
+//!     Signal,
+//!     Trigger,
+//!     runtime::with_owner,
+//! };
 //!
 //! with_owner(|| {
 //!     let count = Signal::new(0i32);
@@ -41,9 +47,9 @@
 //! ## Runtime management
 //!
 //! All reactive primitives must be created within the scope of an active
-//! [`runtime::Owner`]. Use [`runtime::with_owner`] for tests and small examples,
-//! or [`runtime::Owner::new`] + [`runtime::Owner::set`] for long-running
-//! applications.
+//! [`runtime::Owner`]. Use [`runtime::with_owner`] for tests and small
+//! examples, or [`runtime::Owner::new`] + [`runtime::Owner::set`] for
+//! long-running applications.
 
 pub mod effect;
 pub mod memo;

--- a/crates/termoxide_reactive/src/memo.rs
+++ b/crates/termoxide_reactive/src/memo.rs
@@ -4,11 +4,12 @@
 //! It is recomputed only when at least one of its dependencies changes,
 //! avoiding unnecessary recomputations (_memoization_).
 
+use std::fmt;
+
 use reactive_graph::{
     computed::Memo as InnerMemo,
     traits::{Get, GetUntracked, Read, ReadUntracked},
 };
-use std::fmt;
 
 /// Derived value recomputed lazily.
 ///
@@ -18,11 +19,11 @@ use std::fmt;
 /// # Example
 ///
 /// ```
-/// use termoxide_reactive::{Signal, Memo, runtime::with_owner};
+/// use termoxide_reactive::{Memo, Signal, runtime::with_owner};
 ///
 /// with_owner(|| {
-///     let price = Signal::new(10.0f64);
-///     let qty   = Signal::new(3u32);
+///     let price = Signal::new(10f64);
+///     let qty = Signal::new(3u32);
 ///
 ///     let total = Memo::new(move |_prev| price.get() * qty.get() as f64);
 ///
@@ -42,9 +43,7 @@ pub struct Memo<T: Send + Sync + 'static>(pub(crate) InnerMemo<T>);
 
 impl<T: Send + Sync + 'static> Copy for Memo<T> {}
 impl<T: Send + Sync + 'static> Clone for Memo<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
+    fn clone(&self) -> Self { *self }
 }
 
 impl<T: Clone + Send + Sync + PartialEq + 'static> Memo<T> {
@@ -58,14 +57,10 @@ impl<T: Clone + Send + Sync + PartialEq + 'static> Memo<T> {
 
     /// Returns a cloned copy of the computed value **registering
     /// a dependency** in the current reactive context.
-    pub fn get(&self) -> T {
-        self.0.get()
-    }
+    pub fn get(&self) -> T { self.0.get() }
 
     /// Returns a cloned copy **without creating a dependency**.
-    pub fn get_untracked(&self) -> T {
-        self.0.get_untracked()
-    }
+    pub fn get_untracked(&self) -> T { self.0.get_untracked() }
 
     /// Returns a read guard **registering a dependency**.
     pub fn read(&self) -> impl std::ops::Deref<Target = T> + '_ {
@@ -78,12 +73,12 @@ impl<T: Clone + Send + Sync + PartialEq + 'static> Memo<T> {
     }
 
     /// Direct access to the inner `reactive_graph` memo.
-    pub fn inner(&self) -> &InnerMemo<T> {
-        &self.0
-    }
+    pub fn inner(&self) -> &InnerMemo<T> { &self.0 }
 }
 
-impl<T: fmt::Debug + Clone + Send + Sync + PartialEq + 'static> fmt::Debug for Memo<T> {
+impl<T: fmt::Debug + Clone + Send + Sync + PartialEq + 'static> fmt::Debug
+    for Memo<T>
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let val = self.0.read_untracked();
         f.debug_tuple("Memo").field(&*val).finish()

--- a/crates/termoxide_reactive/src/resource.rs
+++ b/crates/termoxide_reactive/src/resource.rs
@@ -3,9 +3,9 @@
 //! [`Resource<T>`] integrates asynchronous data loading.
 //! The result is then exposed via an internal [`Signal`].
 
+use std::{fmt, future::Future};
+
 use crate::signal::Signal;
-use std::fmt;
-use std::future::Future;
 
 /// Loading state of a [`Resource`].
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -16,13 +16,9 @@ pub enum ResourceState<T> {
 }
 
 impl<T> ResourceState<T> {
-    pub fn is_loading(&self) -> bool {
-        matches!(self, ResourceState::Loading)
-    }
+    pub fn is_loading(&self) -> bool { matches!(self, ResourceState::Loading) }
 
-    pub fn is_ready(&self) -> bool {
-        matches!(self, ResourceState::Ready(_))
-    }
+    pub fn is_ready(&self) -> bool { matches!(self, ResourceState::Ready(_)) }
 
     pub fn value(&self) -> Option<&T> {
         if let ResourceState::Ready(v) = self {
@@ -41,12 +37,14 @@ impl<T> ResourceState<T> {
 /// # Example
 ///
 /// ```no_run
-/// use termoxide_reactive::{Resource, Effect, runtime::with_owner};
+/// use termoxide_reactive::{Effect, Resource, runtime::with_owner};
 ///
 /// with_owner(|| {
-///     let user = Resource::new(|| async {
-///         // perform the asynchronous work here
-///         String::from("Alice")
+///     let user = Resource::new(|| {
+///         async {
+///             // perform the asynchronous work here
+///             String::from("Alice")
+///         }
 ///     });
 ///
 ///     assert!(user.state_untracked().is_loading());
@@ -65,9 +63,7 @@ pub struct Resource<T: Clone + 'static> {
 
 impl<T: Clone + 'static> Copy for Resource<T> {}
 impl<T: Clone + 'static> Clone for Resource<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
+    fn clone(&self) -> Self { *self }
 }
 
 impl<T: Clone + 'static> Resource<T> {
@@ -90,7 +86,8 @@ impl<T: Clone + 'static> Resource<T> {
         F: FnOnce() -> Fut + 'static,
         Fut: Future<Output = T> + 'static,
     {
-        let state: Signal<ResourceState<T>> = Signal::new(ResourceState::Loading);
+        let state: Signal<ResourceState<T>> =
+            Signal::new(ResourceState::Loading);
 
         any_spawner::Executor::spawn_local(async move {
             let result = fetcher().await;
@@ -116,7 +113,8 @@ impl<T: Clone + 'static> Resource<T> {
         Fut: Future<Output = Result<T, E>> + 'static,
         E: fmt::Display + 'static,
     {
-        let state: Signal<ResourceState<T>> = Signal::new(ResourceState::Loading);
+        let state: Signal<ResourceState<T>> =
+            Signal::new(ResourceState::Loading);
 
         any_spawner::Executor::spawn_local(async move {
             match fetcher().await {
@@ -129,9 +127,7 @@ impl<T: Clone + 'static> Resource<T> {
     }
 
     /// Returns the current state **registering a reactive dependency**.
-    pub fn state(&self) -> ResourceState<T> {
-        self.state.get()
-    }
+    pub fn state(&self) -> ResourceState<T> { self.state.get() }
 
     /// Returns the current state **without creating a dependency**.
     pub fn state_untracked(&self) -> ResourceState<T> {
@@ -141,9 +137,7 @@ impl<T: Clone + 'static> Resource<T> {
     /// Returns `true` if loading is still in progress.
     ///
     /// Registers a reactive dependency.
-    pub fn is_loading(&self) -> bool {
-        self.state().is_loading()
-    }
+    pub fn is_loading(&self) -> bool { self.state().is_loading() }
 
     /// Returns the value if available, or `None` otherwise.
     ///
@@ -165,9 +159,7 @@ impl<T: Clone + 'static> Resource<T> {
         }
     }
 
-    pub fn as_signal(&self) -> &Signal<ResourceState<T>> {
-        &self.state
-    }
+    pub fn as_signal(&self) -> &Signal<ResourceState<T>> { &self.state }
 }
 
 impl<T: fmt::Debug + Clone + 'static> fmt::Debug for Resource<T> {

--- a/crates/termoxide_reactive/src/runtime.rs
+++ b/crates/termoxide_reactive/src/runtime.rs
@@ -16,8 +16,7 @@ use reactive_graph::owner::Owner as InnerOwner;
 /// # Example
 ///
 /// ```rust
-/// use termoxide_reactive::runtime::Owner;
-/// use termoxide_reactive::Signal;
+/// use termoxide_reactive::{Signal, runtime::Owner};
 ///
 /// let owner = Owner::new();
 /// owner.set(); // activate the owner on the current thread
@@ -29,28 +28,20 @@ pub struct Owner(InnerOwner);
 
 impl Owner {
     /// Create a new reactive owner.
-    pub fn new() -> Self {
-        Self(InnerOwner::new())
-    }
+    pub fn new() -> Self { Self(InnerOwner::new()) }
 
     /// Activate this owner on the current thread.
     ///
     /// Prefer [`Owner::with`] or [`with_owner`] when the scope is
     /// well-defined — they restore the previous owner automatically.
-    pub fn set(&self) {
-        self.0.set();
-    }
+    pub fn set(&self) { self.0.set(); }
 
     /// Execute `f` within the scope of this owner.
-    pub fn with<R>(&self, f: impl FnOnce() -> R) -> R {
-        self.0.with(f)
-    }
+    pub fn with<R>(&self, f: impl FnOnce() -> R) -> R { self.0.with(f) }
 }
 
 impl Default for Owner {
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { Self::new() }
 }
 
 /// Execute `f` in a new reactive scope.

--- a/crates/termoxide_reactive/src/signal.rs
+++ b/crates/termoxide_reactive/src/signal.rs
@@ -3,12 +3,22 @@
 //! [`Signal<T>`] is a single-threaded mutable state that automatically
 //! notifies all its subscribers (memos, effects) on every mutation.
 
+use std::fmt;
+
 use reactive_graph::{
     owner::LocalStorage,
     signal::RwSignal as InnerSignal,
-    traits::{Get, GetUntracked, Read, ReadUntracked, Set, Update, UpdateUntracked, Write},
+    traits::{
+        Get,
+        GetUntracked,
+        Read,
+        ReadUntracked,
+        Set,
+        Update,
+        UpdateUntracked,
+        Write,
+    },
 };
-use std::fmt;
 
 /// Mutable state.
 ///
@@ -34,16 +44,12 @@ pub struct Signal<T: 'static>(pub(crate) InnerSignal<T, LocalStorage>);
 
 impl<T: 'static> Copy for Signal<T> {}
 impl<T: 'static> Clone for Signal<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
+    fn clone(&self) -> Self { *self }
 }
 
 impl<T: 'static> Signal<T> {
     /// Create a new signal with the initial value `value`.
-    pub fn new(value: T) -> Self {
-        Self(InnerSignal::new_local(value))
-    }
+    pub fn new(value: T) -> Self { Self(InnerSignal::new_local(value)) }
 
     /// Returns a cloned copy of the value **registering a dependency**
     pub fn get(&self) -> T
@@ -62,14 +68,10 @@ impl<T: 'static> Signal<T> {
     }
 
     /// Replaces the value and notifies all subscribers.
-    pub fn set(&self, value: T) {
-        self.0.set(value);
-    }
+    pub fn set(&self, value: T) { self.0.set(value); }
 
     /// Modifies the value in place using a closure, then notifies subscribers.
-    pub fn update(&self, f: impl FnOnce(&mut T)) {
-        self.0.update(f);
-    }
+    pub fn update(&self, f: impl FnOnce(&mut T)) { self.0.update(f); }
 
     /// Modifies the value **without notifying** subscribers.
     pub fn update_untracked(&self, f: impl FnOnce(&mut T)) {
@@ -95,9 +97,7 @@ impl<T: 'static> Signal<T> {
         self.0.write()
     }
 
-    pub fn inner(&self) -> &InnerSignal<T, LocalStorage> {
-        &self.0
-    }
+    pub fn inner(&self) -> &InnerSignal<T, LocalStorage> { &self.0 }
 }
 
 impl<T: fmt::Debug + 'static> fmt::Debug for Signal<T> {

--- a/crates/termoxide_reactive/src/stored.rs
+++ b/crates/termoxide_reactive/src/stored.rs
@@ -9,9 +9,12 @@
 //! across renders — timers, RAII guards, mutable scratch buffers,
 //! non-reactive component state.
 
-use reactive_graph::owner::{LocalStorage, StoredValue as InnerStoredValue};
-use reactive_graph::traits::{ReadValue, WriteValue};
 use std::fmt;
+
+use reactive_graph::{
+    owner::{LocalStorage, StoredValue as InnerStoredValue},
+    traits::{ReadValue, WriteValue},
+};
 
 /// Non-reactive, owner-scoped storage.
 ///
@@ -20,7 +23,12 @@ use std::fmt;
 /// # Example
 ///
 /// ```no_run
-/// use termoxide_reactive::{StoredValue, Effect, Trigger, runtime::with_owner};
+/// use termoxide_reactive::{
+///     Effect,
+///     StoredValue,
+///     Trigger,
+///     runtime::with_owner,
+/// };
 ///
 /// with_owner(|| {
 ///     let counter = StoredValue::new(0u32);
@@ -41,16 +49,12 @@ pub struct StoredValue<T: 'static>(InnerStoredValue<T, LocalStorage>);
 
 impl<T: 'static> Copy for StoredValue<T> {}
 impl<T: 'static> Clone for StoredValue<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
+    fn clone(&self) -> Self { *self }
 }
 
 impl<T: 'static> StoredValue<T> {
     /// Store `value` in the current reactive owner's arena.
-    pub fn new(value: T) -> Self {
-        Self(InnerStoredValue::new_local(value))
-    }
+    pub fn new(value: T) -> Self { Self(InnerStoredValue::new_local(value)) }
 
     /// Read the value via a closure (no cloning required).
     pub fn with_value<R>(&self, f: impl FnOnce(&T) -> R) -> R {
@@ -70,9 +74,7 @@ impl<T: 'static> StoredValue<T> {
     }
 
     /// Replace the value.
-    pub fn set(&self, value: T) {
-        self.update(|slot| *slot = value);
-    }
+    pub fn set(&self, value: T) { self.update(|slot| *slot = value); }
 
     /// Return a clone of the value.
     pub fn get_value(&self) -> T
@@ -82,9 +84,7 @@ impl<T: 'static> StoredValue<T> {
         self.with_value(|v| v.clone())
     }
 
-    pub fn inner(&self) -> &InnerStoredValue<T, LocalStorage> {
-        &self.0
-    }
+    pub fn inner(&self) -> &InnerStoredValue<T, LocalStorage> { &self.0 }
 }
 
 impl<T: fmt::Debug + 'static> fmt::Debug for StoredValue<T> {

--- a/crates/termoxide_reactive/src/trigger.rs
+++ b/crates/termoxide_reactive/src/trigger.rs
@@ -4,18 +4,19 @@
 //! manually notifying reactive subscribers (effects, memos) without
 //! storing or exposing data.
 
+use std::fmt;
+
 use reactive_graph::{
     signal::Trigger as InnerTrigger,
     traits::{Notify, Track},
 };
-use std::fmt;
 
 /// Manual reactivity trigger without an associated value.
 ///
 /// # Example
 ///
 /// ```no_run
-/// use termoxide_reactive::{Trigger, Effect, runtime::with_owner};
+/// use termoxide_reactive::{Effect, Trigger, runtime::with_owner};
 ///
 /// with_owner(|| {
 ///     let trigger = Trigger::new();
@@ -33,25 +34,21 @@ pub struct Trigger(pub(crate) InnerTrigger);
 
 impl Trigger {
     /// Create a new trigger.
-    pub fn new() -> Self {
-        Self(InnerTrigger::new())
-    }
+    pub fn new() -> Self { Self(InnerTrigger::new()) }
 
     /// Register this trigger as a dependency in the current reactive context.
     ///
     /// Calling [`notify`](Trigger::notify) later will invalidate the context.
-    pub fn track(&self) {
-        self.0.track();
-    }
+    pub fn track(&self) { self.0.track(); }
 
     /// Notify all reactive contexts that called [`track`](Trigger::track).
-    pub fn notify(&self) {
-        self.0.notify();
-    }
+    pub fn notify(&self) { self.0.notify(); }
 
-    pub fn inner(&self) -> &InnerTrigger {
-        &self.0
-    }
+    pub fn inner(&self) -> &InnerTrigger { &self.0 }
+}
+
+impl Default for Trigger {
+    fn default() -> Self { Self::new() }
 }
 
 impl fmt::Debug for Trigger {

--- a/crates/termoxide_reactive/tests/common/mod.rs
+++ b/crates/termoxide_reactive/tests/common/mod.rs
@@ -22,19 +22,19 @@
 //! Three constraints stack to force this shape:
 //!
 //! 1. **`Effect::new` takes `Fn + 'static`, not `FnMut`.** The effect may
-//!    re-run any number of times, so the closure is called through a
-//!    shared reference — it cannot mutate its captures directly. Interior
-//!    mutability is required to record observations from inside.
+//!    re-run any number of times, so the closure is called through a shared
+//!    reference — it cannot mutate its captures directly. Interior mutability
+//!    is required to record observations from inside.
 //!
-//! 2. **Effects run on the local set (`!Send`).** That makes `Rc` the
-//!    right reference-counted handle (no atomic overhead) and `RefCell`
-//!    the right cell (no locking). `Cell` would work for `Copy` types,
-//!    but `RefCell` handles `Vec`, `String`, etc. uniformly.
+//! 2. **Effects run on the local set (`!Send`).** That makes `Rc` the right
+//!    reference-counted handle (no atomic overhead) and `RefCell` the right
+//!    cell (no locking). `Cell` would work for `Copy` types, but `RefCell`
+//!    handles `Vec`, `String`, etc. uniformly.
 //!
-//! 3. **The test body needs to read the recorded value after the effect
-//!    has run.** Moving the value into the closure would leave nothing to
-//!    assert against, so we share ownership: one `Rc` stays with the test,
-//!    a clone is moved into the closure.
+//! 3. **The test body needs to read the recorded value after the effect has
+//!    run.** Moving the value into the closure would leave nothing to assert
+//!    against, so we share ownership: one `Rc` stays with the test, a clone is
+//!    moved into the closure.
 //!
 //! The clone is scoped to the closure with a block expression
 //! (`Effect::new({ let runs = runs.clone(); move |_| ... })`) so the
@@ -47,6 +47,7 @@
 #![allow(dead_code)]
 
 use std::future::Future;
+
 use termoxide_reactive::runtime::Owner;
 
 /// Install the tokio executor for `any_spawner` exactly once per process.
@@ -62,9 +63,7 @@ pub fn init_executor() {
 ///
 /// Delegates to [`any_spawner::Executor::tick`], which drains pending
 /// local tasks for the current frame.
-pub async fn flush_effects() {
-    any_spawner::Executor::tick().await;
-}
+pub async fn flush_effects() { any_spawner::Executor::tick().await; }
 
 /// Set up the executor and a `LocalSet`, then run `body` inside a fresh
 /// reactive [`Owner`] that is dropped on completion.

--- a/crates/termoxide_reactive/tests/effect.rs
+++ b/crates/termoxide_reactive/tests/effect.rs
@@ -2,10 +2,9 @@
 
 mod common;
 
-use std::cell::RefCell;
-use std::rc::Rc;
-use termoxide_reactive::runtime::Owner;
-use termoxide_reactive::{Effect, Signal};
+use std::{cell::RefCell, rc::Rc};
+
+use termoxide_reactive::{Effect, Signal, runtime::Owner};
 
 #[tokio::test(flavor = "current_thread")]
 async fn runs_once_on_creation() {

--- a/crates/termoxide_reactive/tests/memo.rs
+++ b/crates/termoxide_reactive/tests/memo.rs
@@ -2,10 +2,15 @@
 
 mod common;
 
-use std::cell::RefCell;
-use std::rc::Rc;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    },
+};
+
 use termoxide_reactive::{Effect, Memo, Signal, runtime::with_owner};
 
 #[test]
@@ -66,11 +71,15 @@ fn skips_recompute_when_equal_value_set() {
         // Prime.
         assert_eq!(downstream.get(), 42);
         let before = calls.load(Ordering::SeqCst);
-        // Change source; upstream still yields 42 → downstream should not re-run.
+        // Change source; upstream still yields 42 → downstream should not
+        // re-run.
         src.set(2);
         let _ = downstream.get();
         let after = calls.load(Ordering::SeqCst);
-        assert_eq!(after, before, "downstream must not recompute on equal value");
+        assert_eq!(
+            after, before,
+            "downstream must not recompute on equal value"
+        );
     });
 }
 
@@ -130,7 +139,8 @@ fn prev_argument_carries_last_computed_value() {
     with_owner(|| {
         let src = Signal::new(1i32);
         // Sum-of-inputs accumulator: prev + current.
-        let acc = Memo::new(move |prev: Option<i32>| prev.unwrap_or(0) + src.get());
+        let acc =
+            Memo::new(move |prev: Option<i32>| prev.unwrap_or(0) + src.get());
         assert_eq!(acc.get(), 1); // None + 1
         src.set(2);
         assert_eq!(acc.get(), 3); // 1 + 2

--- a/crates/termoxide_reactive/tests/resource.rs
+++ b/crates/termoxide_reactive/tests/resource.rs
@@ -2,10 +2,9 @@
 
 mod common;
 
-use std::cell::Cell;
-use std::rc::Rc;
-use termoxide_reactive::runtime::with_owner;
-use termoxide_reactive::{Resource, ResourceState};
+use std::{cell::Cell, rc::Rc};
+
+use termoxide_reactive::{Resource, ResourceState, runtime::with_owner};
 
 #[test]
 fn resource_state_predicates() {
@@ -39,7 +38,8 @@ async fn starts_in_loading_state() {
 #[tokio::test(flavor = "current_thread")]
 async fn transitions_to_ready_after_fetcher_resolves() {
     common::run_reactive(async {
-        let r: Resource<String> = Resource::new(|| async { String::from("Alice") });
+        let r: Resource<String> =
+            Resource::new(|| async { String::from("Alice") });
         common::flush_effects().await;
         let state = r.state_untracked();
         assert!(state.is_ready(), "state should be Ready, got {:?}", state);
@@ -52,8 +52,9 @@ async fn transitions_to_ready_after_fetcher_resolves() {
 #[tokio::test(flavor = "current_thread")]
 async fn fallible_resource_records_error_on_err() {
     common::run_reactive(async {
-        let r: Resource<i32> =
-            Resource::new_fallible(|| async { Err::<i32, &'static str>("boom") });
+        let r: Resource<i32> = Resource::new_fallible(|| {
+            async { Err::<i32, &'static str>("boom") }
+        });
         common::flush_effects().await;
         assert_eq!(r.error().as_deref(), Some("boom"));
         assert_eq!(r.get(), None);
@@ -81,7 +82,8 @@ async fn fallible_resource_records_value_on_ok() {
 // `Resource::new` should be cancelled (its body dropped mid-await) so no
 // further work happens.
 #[tokio::test(flavor = "current_thread")]
-#[ignore = "TDD: Resource does not cancel its spawned fetcher when its owner is disposed"]
+#[ignore = "TDD: Resource does not cancel its spawned fetcher when its owner \
+            is disposed"]
 async fn dropping_owner_cancels_pending_fetcher() {
     common::run_reactive(async {
         let body_polled = Rc::new(Cell::new(false));
@@ -91,13 +93,15 @@ async fn dropping_owner_cancels_pending_fetcher() {
         with_owner({
             let body_polled = body_polled.clone();
             || {
-                let _: Resource<i32> = Resource::new(move || async move {
-                    // Runs as soon as the future is polled for the
-                    // first time. With proper cancellation, the task
-                    // is aborted before any first poll and this line
-                    // never executes.
-                    body_polled.set(true);
-                    42
+                let _: Resource<i32> = Resource::new(move || {
+                    async move {
+                        // Runs as soon as the future is polled for the
+                        // first time. With proper cancellation, the task
+                        // is aborted before any first poll and this line
+                        // never executes.
+                        body_polled.set(true);
+                        42
+                    }
                 });
             }
         });
@@ -105,8 +109,8 @@ async fn dropping_owner_cancels_pending_fetcher() {
         common::flush_effects().await;
         assert!(
             !body_polled.get(),
-            "fetcher body was polled after its owner was disposed — \
-             expected the spawned task to be cancelled and the future dropped"
+            "fetcher body was polled after its owner was disposed — expected \
+             the spawned task to be cancelled and the future dropped"
         );
     })
     .await;

--- a/crates/termoxide_reactive/tests/runtime.rs
+++ b/crates/termoxide_reactive/tests/runtime.rs
@@ -1,7 +1,10 @@
 //! Behavior tests for `Owner` and `with_owner`.
 
-use termoxide_reactive::runtime::{Owner, with_owner};
-use termoxide_reactive::{Signal, StoredValue};
+use termoxide_reactive::{
+    Signal,
+    StoredValue,
+    runtime::{Owner, with_owner},
+};
 
 #[test]
 fn with_owner_returns_inner_value() {

--- a/crates/termoxide_reactive/tests/signal.rs
+++ b/crates/termoxide_reactive/tests/signal.rs
@@ -2,8 +2,8 @@
 
 mod common;
 
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
+
 use termoxide_reactive::{Effect, Signal, runtime::with_owner};
 
 #[test]

--- a/crates/termoxide_reactive/tests/stored.rs
+++ b/crates/termoxide_reactive/tests/stored.rs
@@ -2,8 +2,12 @@
 
 mod common;
 
-use termoxide_reactive::runtime::Owner;
-use termoxide_reactive::{Effect, StoredValue, Trigger, runtime::with_owner};
+use termoxide_reactive::{
+    Effect,
+    StoredValue,
+    Trigger,
+    runtime::{Owner, with_owner},
+};
 
 #[test]
 fn get_returns_initial_value() {
@@ -89,7 +93,8 @@ async fn update_does_not_trigger_reactive_effects() {
 fn debug_after_owner_dropped_does_not_panic() {
     // Debug must remain infallible even after disposal — it's relied on
     // by logging, panic formatters, and `dbg!`.
-    let stored = termoxide_reactive::runtime::with_owner(|| StoredValue::new(42i32));
+    let stored =
+        termoxide_reactive::runtime::with_owner(|| StoredValue::new(42i32));
     let s = format!("{:?}", stored);
     assert!(s.contains("<disposed>"), "got {s:?}");
 }

--- a/crates/termoxide_reactive/tests/trigger.rs
+++ b/crates/termoxide_reactive/tests/trigger.rs
@@ -2,8 +2,8 @@
 
 mod common;
 
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
+
 use termoxide_reactive::{Effect, Trigger};
 
 #[tokio::test(flavor = "current_thread")]
@@ -123,7 +123,8 @@ async fn copies_share_underlying_trigger() {
         assert_eq!(
             *runs.borrow(),
             2,
-            "notify via the copy must wake the effect tracking via the original"
+            "notify via the copy must wake the effect tracking via the \
+             original"
         );
     })
     .await;


### PR DESCRIPTION
<!-- TermOxide PR — internal default

     This template is for the original team during the concept phase.

     Keep this PR small and focused. If you're tempted to add a long
     description, consider whether the work should have been split. -->

## Summary

<!-- One or two sentences. What does this PR do and why? -->
Fix all clippy and fmt error in trunk as 05/06/2026

## Related issue

<!-- Use "Closes #123" to auto-close on merge. Use "Part of #123" if
     this is one of several PRs landing the same story. -->

## Reviewer focus

<!-- Optional. Anything tricky, uncertain, or that you want a second
     pair of eyes on. Leave empty if the PR is self-explanatory. -->
     
     This is only fmt and clippy so no new test

## Pre-merge checklist

- [x] PR title follows the squash-merge commit title
- [x] Missing coverage of the new change is explained in reviewer focus
- [ ] Public API changes (if any) are noted in the summary above
- [ ] The linked story/task is updated if scope has shifted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `Unit::is_unset()` helper method for checking unset unit values.

* **Style**
  * Improved code formatting consistency across the codebase with reorganized imports and standardized method formatting.

* **Chores**
  * Enhanced linting configuration for better code quality standards.
  * Refactored `Unit` to derive `Default` trait for improved ergonomics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->