### PR TITLE
event: setup event thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1067,6 +1067,10 @@ dependencies = [
  "guppy-workspace-hack",
  "target-lexicon",
 ]
+
+[[package]]
+name = "termoxide_event"
+version = "0.1.0"
 
 [[package]]
 name = "termoxide_macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/oxidui_style",
     "crates/termoxide_macros",
     "crates/termoxide_reactive",
+    "crates/termoxide_event",
     "crates/cargo-extract",
 ]
 

--- a/crates/termoxide_event/Cargo.toml
+++ b/crates/termoxide_event/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "termoxide_event"
+version = "0.1.0"
+edition = "2024"
+description = "Event system for TermOxide"
+license = "BSD-2-Clause"
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/termoxide_event/src/lib.rs
+++ b/crates/termoxide_event/src/lib.rs
@@ -1,0 +1,28 @@
+use std::{sync::mpsc, thread};
+
+pub fn setup_events() -> mpsc::Receiver<()> {
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        if let Err(error) = tx.send(()) {
+            dbg!(error);
+            return;
+        }
+    });
+
+    return rx;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::setup_events;
+
+    #[test]
+    fn check_receive() {
+        let rx = setup_events();
+        rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(true);
+    }
+}


### PR DESCRIPTION
<!-- TermOxide PR — internal default

     This template is for the original team during the concept phase.

     Keep this PR small and focused. If you're tempted to add a long
     description, consider whether the work should have been split. -->

## Summary

<!-- One or two sentences. What does this PR do and why? -->

Create a new create named `termoxide_event` and implements the beginning the `setup_events()` function to create a thread and a channel

## Related issue

<!-- Use "Closes #123" to auto-close on merge. Use "Part of #123" if
     this is one of several PRs landing the same story. -->

Closes #152

## Reviewer focus

<!-- Optional. Anything tricky, uncertain, or that you want a second
     pair of eyes on. Leave empty if the PR is self-explanatory. -->
- Make sure I use the right module among `mpsc` and `spsc`
- Make sure I use the right channel function (among the 2 availables in mpsc)
- Make sure I create correctly the thread

## Pre-merge checklist

- [x] PR title follows the squash-merge commit title
- [ ] Missing coverage of the new change is explained in reviewer focus
- [ ] Public API changes (if any) are noted in the summary above
- [ ] The linked story/task is updated if scope has shifted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new event-handling component to the workspace.
  * Introduced a simple API for waiting on a startup event signal from background processing.

* **Tests**
  * Added coverage to verify the event signal is received successfully within a short timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->