### PR TITLE
event: integrate crossterm for terminal input event polling

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -207,7 +207,7 @@ jobs:
           for crate in $crates; do
             pkg_args="$pkg_args -p $crate"
           done
-          cargo tarpaulin $pkg_args --out Lcov --output-dir ./coverage
+          cargo tarpaulin $pkg_args --ignore-tests --exclude-files "*/tests/*" --out Lcov --output-dir ./coverage
 
       - name: Upload results to Codecov
         if: always()

--- a/.github/workflows/push-coverage.yml
+++ b/.github/workflows/push-coverage.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          cargo tarpaulin --workspace --exclude cargo-extract --out Lcov --output-dir ./coverage
+          cargo tarpaulin --ignore-tests --exclude-files "*/tests/*" --workspace --exclude cargo-extract --out Lcov --output-dir ./coverage
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,9 @@ dependencies = [
 [[package]]
 name = "termoxide_event"
 version = "0.1.0"
+dependencies = [
+ "crossterm",
+]
 
 [[package]]
 name = "termoxide_macros"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1098,7 @@ name = "termoxide_event"
 version = "0.1.0"
 dependencies = [
  "crossterm",
+ "serial_test",
 ]
 
 [[package]]

--- a/crates/termoxide_event/Cargo.toml
+++ b/crates/termoxide_event/Cargo.toml
@@ -8,5 +8,8 @@ license = "BSD-2-Clause"
 [dependencies]
 crossterm = "0.27"
 
+[dev-dependencies]
+serial_test = "3"
+
 [lints]
 workspace = true

--- a/crates/termoxide_event/Cargo.toml
+++ b/crates/termoxide_event/Cargo.toml
@@ -6,6 +6,7 @@ description = "Event system for TermOxide"
 license = "BSD-2-Clause"
 
 [dependencies]
+crossterm = "0.27"
 
 [lints]
 workspace = true

--- a/crates/termoxide_event/src/crossterm.rs
+++ b/crates/termoxide_event/src/crossterm.rs
@@ -1,0 +1,31 @@
+use std::{io, time::Duration};
+use crossterm::{
+    event::{poll, read},
+    terminal::{disable_raw_mode, enable_raw_mode},
+};
+
+fn print_events() -> io::Result<()> {
+    loop {
+        // Wait up to 1s for another event
+        if poll(Duration::from_millis(1_000))? {
+            // It's guaranteed that read() won't block if `poll` returns `Ok(true)`
+            let event = read()?;
+
+            println!("Event::{event:?}\r");
+
+        } else {
+            // Timeout expired, no event for 1s
+            println!(".\r");
+        }
+    }
+}
+
+pub fn read_events() -> io::Result<()> {
+    enable_raw_mode()?;
+
+    if let Err(e) = print_events() {
+        println!("Error: {e:?}\r");
+    }
+
+    disable_raw_mode()
+}

--- a/crates/termoxide_event/src/crossterm.rs
+++ b/crates/termoxide_event/src/crossterm.rs
@@ -7,8 +7,9 @@ use crossterm::{
 
 pub fn print_events(shutdown: &mpsc::Receiver<()>) -> io::Result<()> {
     loop {
-        if shutdown.try_recv().is_ok() {
-            break;
+        match shutdown.try_recv() {
+            Ok(()) | Err(mpsc::TryRecvError::Disconnected) => break,
+            Err(mpsc::TryRecvError::Empty) => {}
         }
 
         if poll(Duration::from_millis(100))? {

--- a/crates/termoxide_event/src/crossterm.rs
+++ b/crates/termoxide_event/src/crossterm.rs
@@ -28,7 +28,11 @@ pub fn read_events(shutdown: mpsc::Receiver<()>) -> io::Result<()> {
 
     let result = print_events(&shutdown);
 
-    disable_raw_mode()?;
+    if let Err(disable_error) = disable_raw_mode() {
+        if result.is_ok() {
+            return Err(disable_error);
+        }
+    }
 
     result
 }

--- a/crates/termoxide_event/src/crossterm.rs
+++ b/crates/termoxide_event/src/crossterm.rs
@@ -9,7 +9,7 @@ pub fn print_events(shutdown: &mpsc::Receiver<()>) -> io::Result<()> {
     loop {
         match shutdown.try_recv() {
             Ok(()) | Err(mpsc::TryRecvError::Disconnected) => break,
-            Err(mpsc::TryRecvError::Empty) => {}
+            Err(mpsc::TryRecvError::Empty) => {},
         }
 
         if poll(Duration::from_millis(100))? {

--- a/crates/termoxide_event/src/crossterm.rs
+++ b/crates/termoxide_event/src/crossterm.rs
@@ -26,9 +26,9 @@ pub fn print_events(shutdown: &mpsc::Receiver<()>) -> io::Result<()> {
 pub fn read_events(shutdown: mpsc::Receiver<()>) -> io::Result<()> {
     enable_raw_mode()?;
 
-    if let Err(e) = print_events(&shutdown) {
-        println!("Error: {e:?}\r");
-    }
+    let result = print_events(&shutdown);
 
-    disable_raw_mode()
+    disable_raw_mode()?;
+
+    result
 }

--- a/crates/termoxide_event/src/crossterm.rs
+++ b/crates/termoxide_event/src/crossterm.rs
@@ -1,4 +1,5 @@
 use std::{io, sync::mpsc, time::Duration};
+
 use crossterm::{
     event::{poll, read},
     terminal::{disable_raw_mode, enable_raw_mode},
@@ -33,8 +34,9 @@ pub fn read_events(shutdown: mpsc::Receiver<()>) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::print_events;
     use std::{sync::mpsc, thread, time::Duration};
+
+    use super::print_events;
 
     #[test]
     fn print_events_stops_when_shutdown_already_signaled() {
@@ -47,9 +49,9 @@ mod tests {
             let _ = done_tx.send(result);
         });
 
-        let result = done_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("print_events did not return: the shutdown did not break the loop");
+        let result = done_rx.recv_timeout(Duration::from_secs(2)).expect(
+            "print_events did not return: the shutdown did not break the loop",
+        );
         result.expect("print_events returned an error");
     }
 }

--- a/crates/termoxide_event/src/crossterm.rs
+++ b/crates/termoxide_event/src/crossterm.rs
@@ -5,7 +5,7 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode},
 };
 
-fn print_events(shutdown: &mpsc::Receiver<()>) -> io::Result<()> {
+pub fn print_events(shutdown: &mpsc::Receiver<()>) -> io::Result<()> {
     loop {
         if shutdown.try_recv().is_ok() {
             break;
@@ -30,28 +30,4 @@ pub fn read_events(shutdown: mpsc::Receiver<()>) -> io::Result<()> {
     }
 
     disable_raw_mode()
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{sync::mpsc, thread, time::Duration};
-
-    use super::print_events;
-
-    #[test]
-    fn print_events_stops_when_shutdown_already_signaled() {
-        let (shutdown_tx, shutdown_rx) = mpsc::channel();
-        shutdown_tx.send(()).unwrap();
-
-        let (done_tx, done_rx) = mpsc::channel();
-        thread::spawn(move || {
-            let result = print_events(&shutdown_rx);
-            let _ = done_tx.send(result);
-        });
-
-        let result = done_rx.recv_timeout(Duration::from_secs(2)).expect(
-            "print_events did not return: the shutdown did not break the loop",
-        );
-        result.expect("print_events returned an error");
-    }
 }

--- a/crates/termoxide_event/src/crossterm.rs
+++ b/crates/termoxide_event/src/crossterm.rs
@@ -1,31 +1,55 @@
-use std::{io, time::Duration};
+use std::{io, sync::mpsc, time::Duration};
 use crossterm::{
     event::{poll, read},
     terminal::{disable_raw_mode, enable_raw_mode},
 };
 
-fn print_events() -> io::Result<()> {
+fn print_events(shutdown: &mpsc::Receiver<()>) -> io::Result<()> {
     loop {
-        // Wait up to 1s for another event
-        if poll(Duration::from_millis(1_000))? {
-            // It's guaranteed that read() won't block if `poll` returns `Ok(true)`
+        if shutdown.try_recv().is_ok() {
+            break;
+        }
+
+        if poll(Duration::from_millis(100))? {
             let event = read()?;
-
             println!("Event::{event:?}\r");
-
         } else {
-            // Timeout expired, no event for 1s
             println!(".\r");
         }
     }
+
+    Ok(())
 }
 
-pub fn read_events() -> io::Result<()> {
+pub fn read_events(shutdown: mpsc::Receiver<()>) -> io::Result<()> {
     enable_raw_mode()?;
 
-    if let Err(e) = print_events() {
+    if let Err(e) = print_events(&shutdown) {
         println!("Error: {e:?}\r");
     }
 
     disable_raw_mode()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::print_events;
+    use std::{sync::mpsc, thread, time::Duration};
+
+    #[test]
+    fn print_events_stops_when_shutdown_already_signaled() {
+        let (shutdown_tx, shutdown_rx) = mpsc::channel();
+        shutdown_tx.send(()).unwrap();
+
+        let (done_tx, done_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let result = print_events(&shutdown_rx);
+            let _ = done_tx.send(result);
+        });
+
+        let result = done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("print_events did not return: the shutdown did not break the loop");
+        result.expect("print_events returned an error");
+    }
 }

--- a/crates/termoxide_event/src/lib.rs
+++ b/crates/termoxide_event/src/lib.rs
@@ -2,30 +2,66 @@ pub mod crossterm;
 use std::{sync::mpsc, thread};
 use crossterm::read_events;
 
-pub fn setup_events() -> mpsc::Receiver<()> {
-    let (tx, rx) = mpsc::channel();
+pub struct EventHandle {
+    shutdown: mpsc::SyncSender<()>,
+    thread: Option<thread::JoinHandle<()>>,
+}
 
-    thread::spawn(move || {
-        if let Err(error) = tx.send(()) {
+impl Drop for EventHandle {
+    fn drop(&mut self) {
+        let _ = self.shutdown.send(());
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+pub fn setup_events() -> (mpsc::Receiver<()>, EventHandle) {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let (shutdown_tx, shutdown_rx) = mpsc::sync_channel(1);
+
+    let thread = thread::spawn(move || {
+        if let Err(error) = ready_tx.send(()) {
             dbg!(error);
             return;
         }
-        let _ = read_events();
+        let _ = read_events(shutdown_rx);
     });
 
-    return rx;
+    let handle = EventHandle {
+        shutdown: shutdown_tx,
+        thread: Some(thread),
+    };
+
+    (ready_rx, handle)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{sync::mpsc, thread, time::Duration};
 
     use crate::setup_events;
 
     #[test]
     fn check_receive() {
-        let rx = setup_events();
+        let (rx, _handle) = setup_events();
         rx.recv_timeout(Duration::from_secs(2)).unwrap();
         assert!(true);
+    }
+
+    #[test]
+    fn handle_drop_stops_thread() {
+        let (rx, handle) = setup_events();
+        rx.recv().unwrap();
+
+        let (done_tx, done_rx) = mpsc::channel();
+        thread::spawn(move || {
+            drop(handle);
+            let _ = done_tx.send(());
+        });
+
+        done_rx
+            .recv_timeout(Duration::from_secs(3))
+            .expect("EventHandle::drop did not complete: the thread was not stopped");
     }
 }

--- a/crates/termoxide_event/src/lib.rs
+++ b/crates/termoxide_event/src/lib.rs
@@ -1,67 +1,81 @@
 pub mod crossterm;
-use std::{sync::mpsc, thread};
+use std::{sync::mpsc, thread, time::Duration};
+
 use crossterm::read_events;
 
-pub struct EventHandle {
-    shutdown: mpsc::SyncSender<()>,
+pub struct EventStream {
+    receiver: mpsc::Receiver<()>,
+    shutdown: Option<mpsc::SyncSender<()>>,
     thread: Option<thread::JoinHandle<()>>,
 }
 
-impl Drop for EventHandle {
-    fn drop(&mut self) {
-        let _ = self.shutdown.send(());
-        if let Some(handle) = self.thread.take() {
-            let _ = handle.join();
+impl EventStream {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let (shutdown_tx, shutdown_rx) = mpsc::sync_channel(1);
+
+        let thread = thread::spawn(move || {
+            if let Err(error) = ready_tx.send(()) {
+                dbg!(error);
+                return;
+            }
+            let _ = read_events(shutdown_rx);
+        });
+
+        Self {
+            receiver: ready_rx,
+            shutdown: Some(shutdown_tx),
+            thread: Some(thread),
+        }
+    }
+
+    pub fn recv(&self) -> Result<(), mpsc::RecvTimeoutError> {
+        self.receiver.recv_timeout(Duration::from_secs(2))
+    }
+
+    pub fn teardown(mut self) -> thread::Result<()> { self.stop() }
+
+    fn stop(&mut self) -> thread::Result<()> {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        match self.thread.take() {
+            Some(thread) => thread.join(),
+            None => Ok(()),
         }
     }
 }
 
-pub fn setup_events() -> (mpsc::Receiver<()>, EventHandle) {
-    let (ready_tx, ready_rx) = mpsc::channel();
-    let (shutdown_tx, shutdown_rx) = mpsc::sync_channel(1);
-
-    let thread = thread::spawn(move || {
-        if let Err(error) = ready_tx.send(()) {
-            dbg!(error);
-            return;
-        }
-        let _ = read_events(shutdown_rx);
-    });
-
-    let handle = EventHandle {
-        shutdown: shutdown_tx,
-        thread: Some(thread),
-    };
-
-    (ready_rx, handle)
+impl Drop for EventStream {
+    fn drop(&mut self) { let _ = self.stop(); }
 }
 
 #[cfg(test)]
 mod tests {
     use std::{sync::mpsc, thread, time::Duration};
 
-    use crate::setup_events;
+    use crate::EventStream;
 
     #[test]
     fn check_receive() {
-        let (rx, _handle) = setup_events();
-        rx.recv_timeout(Duration::from_secs(2)).unwrap();
-        assert!(true);
+        let events = EventStream::new();
+        events.recv().unwrap();
     }
 
     #[test]
     fn handle_drop_stops_thread() {
-        let (rx, handle) = setup_events();
-        rx.recv().unwrap();
+        let events = EventStream::new();
+        events.recv().unwrap();
 
         let (done_tx, done_rx) = mpsc::channel();
         thread::spawn(move || {
-            drop(handle);
+            drop(events);
             let _ = done_tx.send(());
         });
 
-        done_rx
-            .recv_timeout(Duration::from_secs(3))
-            .expect("EventHandle::drop did not complete: the thread was not stopped");
+        done_rx.recv_timeout(Duration::from_secs(3)).expect(
+            "EventHandle::drop did not complete: the thread was not stopped",
+        );
     }
 }

--- a/crates/termoxide_event/src/lib.rs
+++ b/crates/termoxide_event/src/lib.rs
@@ -50,32 +50,3 @@ impl EventStream {
 impl Drop for EventStream {
     fn drop(&mut self) { let _ = self.stop(); }
 }
-
-#[cfg(test)]
-mod tests {
-    use std::{sync::mpsc, thread, time::Duration};
-
-    use crate::EventStream;
-
-    #[test]
-    fn check_receive() {
-        let events = EventStream::new();
-        events.recv().unwrap();
-    }
-
-    #[test]
-    fn handle_drop_stops_thread() {
-        let events = EventStream::new();
-        events.recv().unwrap();
-
-        let (done_tx, done_rx) = mpsc::channel();
-        thread::spawn(move || {
-            drop(events);
-            let _ = done_tx.send(());
-        });
-
-        done_rx.recv_timeout(Duration::from_secs(3)).expect(
-            "EventHandle::drop did not complete: the thread was not stopped",
-        );
-    }
-}

--- a/crates/termoxide_event/src/lib.rs
+++ b/crates/termoxide_event/src/lib.rs
@@ -1,4 +1,6 @@
+pub mod crossterm;
 use std::{sync::mpsc, thread};
+use crossterm::read_events;
 
 pub fn setup_events() -> mpsc::Receiver<()> {
     let (tx, rx) = mpsc::channel();
@@ -8,6 +10,7 @@ pub fn setup_events() -> mpsc::Receiver<()> {
             dbg!(error);
             return;
         }
+        let _ = read_events();
     });
 
     return rx;

--- a/crates/termoxide_event/src/lib.rs
+++ b/crates/termoxide_event/src/lib.rs
@@ -20,7 +20,9 @@ impl EventStream {
                 dbg!(error);
                 return;
             }
-            let _ = read_events(shutdown_rx);
+            if let Err(error) = read_events(shutdown_rx) {
+                dbg!(error);
+            }
         });
 
         Self {

--- a/crates/termoxide_event/tests/crossterm.rs
+++ b/crates/termoxide_event/tests/crossterm.rs
@@ -5,7 +5,10 @@ use termoxide_event::crossterm::print_events;
 #[test]
 fn print_events_stops_when_shutdown_already_signaled() {
     let (shutdown_tx, shutdown_rx) = mpsc::channel();
-    shutdown_tx.send(()).unwrap();
+    assert!(
+        shutdown_tx.send(()).is_ok(),
+        "Failed to send shutdown signal"
+    );
 
     let (done_tx, done_rx) = mpsc::channel();
     thread::spawn(move || {
@@ -13,8 +16,10 @@ fn print_events_stops_when_shutdown_already_signaled() {
         let _ = done_tx.send(result);
     });
 
-    let result = done_rx.recv_timeout(Duration::from_secs(2)).expect(
-        "print_events did not return: the shutdown did not break the loop",
+    let result = done_rx.recv_timeout(Duration::from_secs(2));
+    assert!(
+        result.is_ok(),
+        "print_events returned an error: {:?}",
+        result.err()
     );
-    result.expect("print_events returned an error");
 }

--- a/crates/termoxide_event/tests/crossterm.rs
+++ b/crates/termoxide_event/tests/crossterm.rs
@@ -1,0 +1,20 @@
+use std::{sync::mpsc, thread, time::Duration};
+
+use termoxide_event::crossterm::print_events;
+
+#[test]
+fn print_events_stops_when_shutdown_already_signaled() {
+    let (shutdown_tx, shutdown_rx) = mpsc::channel();
+    shutdown_tx.send(()).unwrap();
+
+    let (done_tx, done_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let result = print_events(&shutdown_rx);
+        let _ = done_tx.send(result);
+    });
+
+    let result = done_rx.recv_timeout(Duration::from_secs(2)).expect(
+        "print_events did not return: the shutdown did not break the loop",
+    );
+    result.expect("print_events returned an error");
+}

--- a/crates/termoxide_event/tests/lib.rs
+++ b/crates/termoxide_event/tests/lib.rs
@@ -27,3 +27,29 @@ fn handle_drop_stops_thread() {
         "EventHandle::drop did not complete: the thread was not stopped"
     );
 }
+
+#[test]
+fn check_teardown_stops_thread() {
+    let events = EventStream::new();
+    assert!(
+        events.recv().is_ok(),
+        "EventStream::recv() failed before calling teardown"
+    );
+
+    let (done_tx, done_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = events.teardown();
+        let _ = done_tx.send(());
+    });
+
+    assert!(
+        done_rx.recv_timeout(Duration::from_secs(3)).is_ok(),
+        "EventHandle::teardown did not complete: the thread was not stopped"
+    );
+}
+
+#[test]
+fn ready_send_fails_if_receiver_is_dropped_early() {
+    let events = EventStream::new();
+    drop(events);
+}

--- a/crates/termoxide_event/tests/lib.rs
+++ b/crates/termoxide_event/tests/lib.rs
@@ -1,14 +1,17 @@
 use std::{sync::mpsc, thread, time::Duration};
 
+use serial_test::serial;
 use termoxide_event::EventStream;
 
 #[test]
+#[serial]
 fn check_receive() {
     let events = EventStream::new();
     assert!(events.recv().is_ok(), "EventStream::recv() failed");
 }
 
 #[test]
+#[serial]
 fn handle_drop_stops_thread() {
     let events = EventStream::new();
     assert!(
@@ -29,6 +32,7 @@ fn handle_drop_stops_thread() {
 }
 
 #[test]
+#[serial]
 fn check_teardown_stops_thread() {
     let events = EventStream::new();
     assert!(
@@ -49,6 +53,7 @@ fn check_teardown_stops_thread() {
 }
 
 #[test]
+#[serial]
 fn ready_send_fails_if_receiver_is_dropped_early() {
     let events = EventStream::new();
     drop(events);

--- a/crates/termoxide_event/tests/lib.rs
+++ b/crates/termoxide_event/tests/lib.rs
@@ -1,0 +1,25 @@
+use std::{sync::mpsc, thread, time::Duration};
+
+use termoxide_event::EventStream;
+
+#[test]
+fn check_receive() {
+    let events = EventStream::new();
+    events.recv().unwrap();
+}
+
+#[test]
+fn handle_drop_stops_thread() {
+    let events = EventStream::new();
+    events.recv().unwrap();
+
+    let (done_tx, done_rx) = mpsc::channel();
+    thread::spawn(move || {
+        drop(events);
+        let _ = done_tx.send(());
+    });
+
+    done_rx.recv_timeout(Duration::from_secs(3)).expect(
+        "EventHandle::drop did not complete: the thread was not stopped",
+    );
+}

--- a/crates/termoxide_event/tests/lib.rs
+++ b/crates/termoxide_event/tests/lib.rs
@@ -5,13 +5,16 @@ use termoxide_event::EventStream;
 #[test]
 fn check_receive() {
     let events = EventStream::new();
-    events.recv().unwrap();
+    assert!(events.recv().is_ok(), "EventStream::recv() failed");
 }
 
 #[test]
 fn handle_drop_stops_thread() {
     let events = EventStream::new();
-    events.recv().unwrap();
+    assert!(
+        events.recv().is_ok(),
+        "EventStream::recv() failed before dropping the handle"
+    );
 
     let (done_tx, done_rx) = mpsc::channel();
     thread::spawn(move || {
@@ -19,7 +22,8 @@ fn handle_drop_stops_thread() {
         let _ = done_tx.send(());
     });
 
-    done_rx.recv_timeout(Duration::from_secs(3)).expect(
-        "EventHandle::drop did not complete: the thread was not stopped",
+    assert!(
+        done_rx.recv_timeout(Duration::from_secs(3)).is_ok(),
+        "EventHandle::drop did not complete: the thread was not stopped"
     );
 }


### PR DESCRIPTION
<!-- TermOxide PR — internal default

     This template is for the original team during the concept phase.

     Keep this PR small and focused. If you're tempted to add a long
     description, consider whether the work should have been split. -->

## Summary

<!-- One or two sentences. What does this PR do and why? -->
Integrated crossterm in the event thread to poll events
Refactored `setup_events()` into `impl EventStream` to implement the `drop` function to be able to stop properly the event thread

## Related issue

<!-- Use "Closes #123" to auto-close on merge. Use "Part of #123" if
     this is one of several PRs landing the same story. -->

Closes #104

## Reviewer focus

<!-- Optional. Anything tricky, uncertain, or that you want a second
     pair of eyes on. Leave empty if the PR is self-explanatory. -->

## Pre-merge checklist

- [x] PR title follows the squash-merge commit title
- [ ] Missing coverage of the new change is explained in reviewer focus
- [ ] Public API changes (if any) are noted in the summary above
- [ ] The linked story/task is updated if scope has shifted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `EventStream` interface for consuming terminal events with explicit lifecycle controls (receive, teardown, and automatic cleanup on drop).
  * Enabled terminal event handling via `crossterm`, with polling-based updates and clean startup/shutdown behavior.

* **Bug Fixes**
  * Improved reliability of the event-loop shutdown so it stops promptly when signaled or when the stream is dropped.

* **Tests**
  * Added/expanded coverage to verify prompt shutdown behavior when a shutdown signal is already queued, and that dropping/tearing down stops background processing quickly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->