### PR TITLE
ci/codecov: add push and on-demand coverage baseline uploads

### DIFF
--- a/.github/workflows/push-coverage.yml
+++ b/.github/workflows/push-coverage.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - dev/trunk
       - main
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: "Branch to upload a coverage report for"
+        required: true
+        default: "dev/trunk"
+        type: string
 
 jobs:
   upload-coverage:
@@ -12,10 +19,20 @@ jobs:
     environment: codecov
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve target ref
+        id: ref
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "ref=${{ inputs.target_branch }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ steps.ref.outputs.ref }}
           persist-credentials: false
 
       - name: Setup Rust & push cache
@@ -39,3 +56,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
+          override_branch: ${{ steps.ref.outputs.ref }}

--- a/.github/workflows/push-coverage.yml
+++ b/.github/workflows/push-coverage.yml
@@ -12,6 +12,11 @@ on:
         required: true
         default: "dev/trunk"
         type: string
+      target_commit:
+        description: "Optional specific commit SHA to check out instead of the tip of target_branch"
+        required: false
+        default: ""
+        type: string
 
 jobs:
   upload-coverage:
@@ -23,16 +28,23 @@ jobs:
         id: ref
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "ref=${{ inputs.target_branch }}" >> "$GITHUB_OUTPUT"
+            commit="${{ inputs.target_commit }}"
+            if [[ -n "$commit" ]]; then
+              echo "checkout_ref=$commit" >> "$GITHUB_OUTPUT"
+            else
+              echo "checkout_ref=${{ inputs.target_branch }}" >> "$GITHUB_OUTPUT"
+            fi
+            echo "branch=${{ inputs.target_branch }}" >> "$GITHUB_OUTPUT"
           else
-            echo "ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            echo "checkout_ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            echo "branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ steps.ref.outputs.ref }}
+          ref: ${{ steps.ref.outputs.checkout_ref }}
           persist-credentials: false
 
       - name: Setup Rust & push cache
@@ -56,4 +68,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
-          override_branch: ${{ steps.ref.outputs.ref }}
+          override_branch: ${{ steps.ref.outputs.branch }}

--- a/.github/workflows/push-coverage.yml
+++ b/.github/workflows/push-coverage.yml
@@ -22,22 +22,28 @@ jobs:
   upload-coverage:
     name: Tests & Coverage
     environment: codecov
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Resolve target ref
         id: ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TARGET_COMMIT: ${{ inputs.target_commit }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            commit="${{ inputs.target_commit }}"
-            if [[ -n "$commit" ]]; then
-              echo "checkout_ref=$commit" >> "$GITHUB_OUTPUT"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ -n "$TARGET_COMMIT" ]]; then
+              echo "checkout_ref=$TARGET_COMMIT" >> "$GITHUB_OUTPUT"
             else
-              echo "checkout_ref=${{ inputs.target_branch }}" >> "$GITHUB_OUTPUT"
+              echo "checkout_ref=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
             fi
-            echo "branch=${{ inputs.target_branch }}" >> "$GITHUB_OUTPUT"
+            echo "branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
           else
-            echo "checkout_ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-            echo "branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            echo "checkout_ref=$REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "branch=$REF_NAME" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout repository

--- a/.github/workflows/push-coverage.yml
+++ b/.github/workflows/push-coverage.yml
@@ -1,0 +1,41 @@
+name: Push Coverage Baseline
+
+on:
+  push:
+    branches:
+      - dev/trunk
+      - main
+
+jobs:
+  upload-coverage:
+    name: Tests & Coverage
+    environment: codecov
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Rust & push cache
+        uses: ./.github/actions/rust-cache
+        with:
+          action: push
+          packages: '["cargo-tarpaulin"]'
+
+      - name: Restore Rust cache
+        uses: ./.github/actions/rust-cache
+        with:
+          action: pull
+          packages: '["cargo-tarpaulin"]'
+
+      - name: Run tests with coverage
+        run: |
+          cargo tarpaulin --workspace --exclude cargo-extract --out Lcov --output-dir ./coverage
+
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info


### PR DESCRIPTION
## Summary

Codecov never gets a report for `dev/trunk` or `main` since coverage only uploads during PR-triggered runs, which check out the PR head, not the target branch — every PR shows "missing base commit" once its base moves past reviewed code. Adds a push-triggered workflow that backfills that baseline automatically, plus a `workflow_dispatch` to upload on demand for any branch or historical commit.

## Reviewer focus

- `override_branch` is required on the manual-dispatch path: checking out an explicit `ref`/commit leaves a detached HEAD, so Codecov can't infer the branch name on its own.
- `target_commit` exists specifically to backfill commits that predate this workflow (e.g. PR #158, the current `dev/trunk` head) without needing a new push.
- No Rust code changed, so there's no test coverage to add for this PR itself.

## Pre-merge checklist

- [x] PR title follows the squash-merge commit title
- [x] Missing coverage of the new change is explained in reviewer focus
- [x] Public API changes (if any) are noted in the summary above
- [x] The linked story/task is updated if scope has shifted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated coverage pipeline for Rust tests on key branches and manual runs.
  * Coverage reports are now generated and uploaded to Codecov for easier tracking of test health.
  * The workflow supports both branch-based runs and optional commit-specific checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->