### PR TITLE
ci/tools: skip cargo install when a partial cache hit already has it

### DIFF
--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -88,6 +88,10 @@ runs:
       run: |
         packages='${{ inputs.packages }}'
         for pkg in $(echo "$packages" | jq -r '.[]'); do
+          if [ -x "$HOME/.cargo/bin/$pkg" ]; then
+            echo "${pkg} already present in cargo bin (restored from a partial cache hit), skipping install"
+            continue
+          fi
           echo "::group::Installing ${pkg}"
           cargo install "$pkg" --locked
           echo "::endgroup::"


### PR DESCRIPTION
## Summary

`restore-keys` falls back to an older cache when the exact key misses (e.g. a different `Cargo.lock` hash across branches), restoring an already-installed binary — but `cache-hit` only reports `true` on an exact match, so the install step still ran `cargo install`, which refuses to overwrite an existing binary without `--force`. Check for the binary first instead of forcing every reinstall.

## Reviewer focus

- Reproduced on the `push-coverage.yml` runs from #160: the `push`-triggered run cached `cargo-tarpaulin`, then a `workflow_dispatch` run against a different branch missed the exact key, fell back to that cache via `restore-keys`, and failed with `binary 'cargo-tarpaulin' already exists in destination`.
- Fix checks `$HOME/.cargo/bin/$pkg` directly rather than relying on `PATH`, since the "Add cargo bin to PATH" step in this same action runs after this one.

## Pre-merge checklist

- [x] PR title follows the squash-merge commit title
- [x] Missing coverage of the new change is explained in reviewer focus
- [x] Public API changes (if any) are noted in the summary above
- [x] The linked story/task is updated if scope has shifted