### PR TITLE
ci/codecov: backport push-coverage baseline workflow to dev/trunk

### DIFF
--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -88,6 +88,10 @@ runs:
       run: |
         packages='${{ inputs.packages }}'
         for pkg in $(echo "$packages" | jq -r '.[]'); do
+          if [ -x "$HOME/.cargo/bin/$pkg" ]; then
+            echo "${pkg} already present in cargo bin (restored from a partial cache hit), skipping install"
+            continue
+          fi
           echo "::group::Installing ${pkg}"
           cargo install "$pkg" --locked
           echo "::endgroup::"

--- a/.github/workflows/push-coverage.yml
+++ b/.github/workflows/push-coverage.yml
@@ -1,0 +1,77 @@
+name: Push Coverage Baseline
+
+on:
+  push:
+    branches:
+      - dev/trunk
+      - main
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: "Branch to upload a coverage report for"
+        required: true
+        default: "dev/trunk"
+        type: string
+      target_commit:
+        description: "Optional specific commit SHA to check out instead of the tip of target_branch"
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  upload-coverage:
+    name: Tests & Coverage
+    environment: codecov
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve target ref
+        id: ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TARGET_COMMIT: ${{ inputs.target_commit }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ -n "$TARGET_COMMIT" ]]; then
+              echo "checkout_ref=$TARGET_COMMIT" >> "$GITHUB_OUTPUT"
+            else
+              echo "checkout_ref=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+            fi
+            echo "branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+          else
+            echo "checkout_ref=$REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "branch=$REF_NAME" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.ref.outputs.checkout_ref }}
+          persist-credentials: false
+
+      - name: Setup Rust & push cache
+        uses: ./.github/actions/rust-cache
+        with:
+          action: push
+          packages: '["cargo-tarpaulin"]'
+
+      - name: Restore Rust cache
+        uses: ./.github/actions/rust-cache
+        with:
+          action: pull
+          packages: '["cargo-tarpaulin"]'
+
+      - name: Run tests with coverage
+        run: |
+          cargo tarpaulin --workspace --exclude cargo-extract --out Lcov --output-dir ./coverage
+
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          override_branch: ${{ steps.ref.outputs.branch }}


### PR DESCRIPTION
## Summary

`push-coverage.yml` and its cache-install fix (#160, #161) only merged into `main`; `dev/trunk` never got them since changes there don't flow back automatically. Cherry-picks both commits so pushes to `dev/trunk` actually start uploading a Codecov baseline, same as `main` already does.

## Reviewer focus

- Both commits cherry-picked cleanly with no conflicts — `dev/trunk`'s copy of `rust-cache/action.yml` was byte-identical to `main`'s pre-fix version.
- No new review needed on the logic itself; already reviewed and merged as #160 and #161.

## Pre-merge checklist

- [x] PR title follows the squash-merge commit title
- [x] Missing coverage of the new change is explained in reviewer focus
- [x] Public API changes (if any) are noted in the summary above
- [x] The linked story/task is updated if scope has shifted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a coverage upload workflow that runs on key branch pushes and can also be triggered manually, producing and sending test coverage reports automatically.

* **Bug Fixes**
  * Improved package installation caching so already-available command-line tools are skipped, reducing unnecessary reinstall steps and speeding up runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->