### PR TITLE
ci/codecov: set override_commit so backfills land on the right commit

### DIFF
--- a/.github/workflows/push-coverage.yml
+++ b/.github/workflows/push-coverage.yml
@@ -53,6 +53,14 @@ jobs:
           ref: ${{ steps.ref.outputs.checkout_ref }}
           persist-credentials: false
 
+      # codecov-action falls back to GITHUB_SHA when override_commit isn't set,
+      # which for workflow_dispatch is the ref that launched the run, not the
+      # commit actually checked out above. Resolve it explicitly so backfills
+      # land on the right commit instead of the dispatch ref's tip.
+      - name: Resolve checked-out commit
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Setup Rust & push cache
         uses: ./.github/actions/rust-cache
         with:
@@ -75,3 +83,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           override_branch: ${{ steps.ref.outputs.branch }}
+          override_commit: ${{ steps.commit.outputs.sha }}


### PR DESCRIPTION
## Summary

`codecov-action` falls back to `GITHUB_SHA` when `override_commit` isn't set — but for `workflow_dispatch`, that's the ref that launched the run, not the `target_branch`/`target_commit` actually checked out inside the job. Every backfill dispatch so far has silently uploaded against the dispatch ref's own tip instead of the intended commit, which is why PR #158's base commit still shows as missing despite a "successful" backfill run.

## Reviewer focus

- Resolves the actual checked-out SHA via `git rev-parse HEAD` right after checkout, rather than trusting `target_commit`/`target_branch` directly, since a branch name can move and we need the exact commit that was actually tested.
- Confirmed via a real dispatch run: the upload log reported queuing against `9ef77271` (the dispatch ref's tip) while we'd targeted `06ab1d0` — no `override_commit` was present in the action's env dump at all.

## Pre-merge checklist

- [x] PR title follows the squash-merge commit title
- [x] Missing coverage of the new change is explained in reviewer focus
- [x] Public API changes (if any) are noted in the summary above
- [x] The linked story/task is updated if scope has shifted