### PR TITLE
event: add non-blocking poll_events to EventStream

### DIFF
--- a/crates/termoxide_event/examples/main.rs
+++ b/crates/termoxide_event/examples/main.rs
@@ -1,0 +1,38 @@
+use std::{
+    error::Error,
+    io::{self, Write},
+    thread,
+    time::Duration,
+};
+
+use termoxide_event::{
+    EventStream,
+    event::{Event, KeyCode},
+};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let stream = EventStream::new();
+
+    // Poll loop: drain whatever input arrived, react to it, then sleep a
+    // frame budget so we don't busy-wait. The `'run` label lets us break out
+    // of the outer loop from inside the inner `for`.
+    'run: loop {
+        for event in stream.poll_events() {
+            println!("Received event: {event:?}\r");
+            io::stdout().flush()?;
+            if matches!(event, Event::KeyPress(KeyCode::Esc)) {
+                println!("Exiting...\r");
+                io::stdout().flush()?;
+                break 'run;
+            }
+        }
+        thread::sleep(Duration::from_millis(16));
+    }
+
+    // Stop the reader thread and restore the terminal, inspecting the outcome.
+    match stream.teardown() {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(Box::new(error)),
+        Err(_panic) => Err("reader thread panicked".into()),
+    }
+}

--- a/crates/termoxide_event/src/lib.rs
+++ b/crates/termoxide_event/src/lib.rs
@@ -110,6 +110,20 @@ impl EventStream {
         self.receiver.recv()
     }
 
+    /// Poll for all events currently available.
+    ///
+    /// Returns a vector of all events currently available, or an empty vector
+    /// if none are ready. The order of events is preserved.
+    /// This is a non-blocking call, so it will return
+    /// immediately even if no events are ready.
+    pub fn poll_events(&self) -> Vec<Event> {
+        let mut events = Vec::new();
+        while let Ok(event) = self.receiver.try_recv() {
+            events.push(event);
+        }
+        events
+    }
+
     /// Stop the stream explicitly and wait for the reader thread to finish.
     ///
     /// Consumes the handle, signals shutdown, and joins the thread — the same

--- a/crates/termoxide_event/src/lib.rs
+++ b/crates/termoxide_event/src/lib.rs
@@ -96,20 +96,6 @@ impl EventStream {
         }
     }
 
-    /// Block until the next event arrives.
-    ///
-    /// Waits indefinitely for the reader thread to produce an event. The very
-    /// first call is guaranteed to return [`Event::ChannelReady`], so it never
-    /// hangs on a freshly created stream. Returns
-    /// [`RecvError`](mpsc::RecvError) once the reader thread has stopped and
-    /// the channel is closed.
-    ///
-    /// This is a temporary interface that will be superseded by a dedicated
-    /// polling method.
-    pub fn recv(&self) -> Result<Event, mpsc::RecvError> {
-        self.receiver.recv()
-    }
-
     /// Poll for all events currently available.
     ///
     /// Returns a vector of all events currently available, or an empty vector

--- a/crates/termoxide_event/src/lib.rs
+++ b/crates/termoxide_event/src/lib.rs
@@ -20,16 +20,26 @@
 //! ## Quickstart
 //!
 //! ```no_run
+//! use std::{thread, time::Duration};
+//!
 //! use termoxide_event::{EventStream, event::Event};
 //!
 //! let events = EventStream::new();
 //!
-//! // The first event is always `Event::ChannelReady`: the reader is live.
-//! while let Ok(event) = events.recv() {
-//!     match event {
-//!         Event::ChannelReady => println!("stream ready"),
-//!         Event::KeyPress(code) => println!("key pressed: {code:?}"),
+//! // `poll_events` never blocks: it drains whatever input is pending and
+//! // returns an empty `Vec` when nothing is ready, so the loop must set its
+//! // own pace. The first event is always `Event::ChannelReady`.
+//! 'run: loop {
+//!     for event in events.poll_events() {
+//!         match event {
+//!             Event::ChannelReady => println!("stream ready"),
+//!             Event::KeyPress(code) => {
+//!                 println!("key pressed: {code:?}");
+//!                 break 'run;
+//!             },
+//!         }
 //!     }
+//!     thread::sleep(Duration::from_millis(16));
 //! }
 //!
 //! // Stop the reader thread and restore the terminal, surfacing any error the
@@ -51,8 +61,8 @@ use event::Event;
 ///
 /// Creating an `EventStream` spawns a thread that puts the terminal into raw
 /// mode and streams [`Event`]s back over a channel. The application consumes
-/// them with [`recv`](Self::recv). The very first event is always
-/// [`Event::ChannelReady`].
+/// them with [`poll_events`](Self::poll_events). The very first event is
+/// always [`Event::ChannelReady`].
 ///
 /// Shutdown is cooperative: dropping the handle (or calling
 /// [`teardown`](Self::teardown)) signals the thread to stop, joins it, and

--- a/crates/termoxide_event/src/lib.rs
+++ b/crates/termoxide_event/src/lib.rs
@@ -109,9 +109,17 @@ impl EventStream {
     /// Poll for all events currently available.
     ///
     /// Returns a vector of all events currently available, or an empty vector
-    /// if none are ready. The order of events is preserved.
-    /// This is a non-blocking call, so it will return
-    /// immediately even if no events are ready.
+    /// if none are ready. The order of events is preserved. This is a
+    /// non-blocking call, so it returns immediately even if no events are
+    /// ready — including before the reader thread has sent its initial
+    /// [`Event::ChannelReady`].
+    ///
+    /// An empty vector does **not** signal end of stream: this method cannot
+    /// distinguish "nothing pending yet" from "the reader thread has stopped
+    /// and the channel is closed". To observe the reader stopping — and to
+    /// surface any [`SendEventError`] it stopped on — call
+    /// [`teardown`](Self::teardown) rather than inferring shutdown from an
+    /// empty poll.
     pub fn poll_events(&self) -> Vec<Event> {
         let mut events = Vec::new();
         while let Ok(event) = self.receiver.try_recv() {

--- a/crates/termoxide_event/tests/lib.rs
+++ b/crates/termoxide_event/tests/lib.rs
@@ -6,26 +6,57 @@
 //! into raw mode; running two at once would let them fight over the terminal
 //! and interleave raw-mode toggling non-deterministically.
 
-use std::{sync::mpsc, thread, time::Duration};
+use std::{
+    sync::mpsc,
+    thread,
+    time::{Duration, Instant},
+};
 
 use serial_test::serial;
-use termoxide_event::EventStream;
+use termoxide_event::{EventStream, event::Event};
+
+/// Block the test until the stream yields at least one event, or fail after a
+/// deadline.
+///
+/// Unlike the old blocking `recv`, [`EventStream::poll_events`] is
+/// non-blocking and returns an empty `Vec` when nothing is pending, so a
+/// single call right after startup can race ahead of the reader thread's
+/// `ChannelReady`. This helper restores the "wait until the stream is live"
+/// barrier the lifecycle tests rely on by polling until something arrives.
+fn wait_for_events(events: &EventStream) -> Vec<Event> {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let batch = events.poll_events();
+        if !batch.is_empty() {
+            return batch;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "EventStream::poll_events() never yielded an event within the \
+             timeout"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
 
 #[test]
 #[serial]
 fn check_receive() {
     let events = EventStream::new();
-    assert!(events.recv().is_ok(), "EventStream::recv() failed");
+    let received = wait_for_events(&events);
+    assert_eq!(
+        received.first(),
+        Some(&Event::ChannelReady),
+        "the first polled event should be ChannelReady"
+    );
 }
 
 #[test]
 #[serial]
 fn handle_drop_stops_thread() {
     let events = EventStream::new();
-    assert!(
-        events.recv().is_ok(),
-        "EventStream::recv() failed before dropping the handle"
-    );
+    // Barrier: make sure the reader thread is live before we drop the handle.
+    wait_for_events(&events);
 
     // Run the drop (which joins the reader thread) on a side thread and wait
     // on it with a timeout: if the join ever hangs, the test fails after 3s
@@ -46,10 +77,8 @@ fn handle_drop_stops_thread() {
 #[serial]
 fn check_teardown_stops_thread() {
     let events = EventStream::new();
-    assert!(
-        events.recv().is_ok(),
-        "EventStream::recv() failed before calling teardown"
-    );
+    // Barrier: make sure the reader thread is live before we tear it down.
+    wait_for_events(&events);
 
     // Same timeout guard as `handle_drop_stops_thread`, but exercising the
     // explicit `teardown` path rather than `Drop`.
@@ -68,11 +97,11 @@ fn check_teardown_stops_thread() {
 #[test]
 #[serial]
 fn drop_immediately_shuts_down_cleanly() {
-    // Drop the stream right away, without ever calling `recv`. Depending on
-    // timing the reader thread may or may not have sent `ChannelReady` yet, so
-    // the `ChannelReady` send may succeed or fail — either way the thread must
-    // shut down without panicking. Reaching the end of the test is the
-    // assertion: `drop` signals shutdown and joins the thread cleanly.
+    // Drop the stream right away, without ever polling. Depending on timing the
+    // reader thread may or may not have sent `ChannelReady` yet, so the
+    // `ChannelReady` send may succeed or fail — either way the thread must shut
+    // down without panicking. Reaching the end of the test is the assertion:
+    // `drop` signals shutdown and joins the thread cleanly.
     let events = EventStream::new();
     drop(events);
 }


### PR DESCRIPTION
## Summary

Replaces the temporary blocking `recv` with a non-blocking `poll_events()`
that drains every pending event into a `Vec<Event>` and returns immediately,
wiring the public consumption API for the input stream. Adds a runnable
`examples/main.rs` demonstrating the poll → react → sleep loop and clean
`teardown`.

**Public API change:** `EventStream::recv()` is removed; consumers now use
`EventStream::poll_events() -> Vec<Event>`. An empty `Vec` means "nothing
pending", not "stream closed" — this is documented on the method, and shutdown
is observed via `teardown()` instead.

## Related issue

Part of #24

## Reviewer focus

- `poll_events` collapses `try_recv`'s `Empty` and `Disconnected` into an empty
  `Vec`, so a poll loop cannot detect the reader thread dying. This is an
  accepted trade-off for the non-blocking signature and is documented; the
  reader's `SendEventError` is surfaced through `teardown()`.
- Lifecycle tests gained a `wait_for_events` polling barrier to replace the
  synchronisation the old blocking `recv` gave for free.
- `examples/main.rs` is force-added (the tree excludes `**/examples/**`) and is
  not exercised by CI beyond `cargo build --examples`.

## Pre-merge checklist

- [x] PR title follows the squash-merge commit title
- [x] Missing coverage of the new change is explained in reviewer focus
- [x] Public API changes (if any) are noted in the summary above
- [ ] The linked story/task is updated if scope has shifted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added non-blocking event polling that returns all currently available events in order.
  - Updated examples to process events continuously and exit when Escape is pressed.
  - Added handling for channel readiness events.

- **Breaking Changes**
  - Replaced the blocking `recv` method with `poll_events`.
  - Empty polling results no longer indicate that the event stream has stopped; use teardown to detect shutdown or errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->