### PR TITLE
ci/codecov-review: trigger on codecov check_run instead of pr-validator

### DIFF
--- a/.github/workflows/pr-codecov-review.yml
+++ b/.github/workflows/pr-codecov-review.yml
@@ -1,13 +1,17 @@
 name: Update PR Codecov Review
 
 on:
-  workflow_run:
-    workflows: ["pr-validator"]
+  check_run:
     types: [completed]
+
+concurrency:
+  group: codecov-review-${{ github.event.check_run.head_sha }}
 
 jobs:
   update-codecov-section:
     runs-on: ubuntu-latest
+    # check_run has no trigger-level filter, so restrict to Codecov's own app here.
+    if: github.event.check_run.app.slug == 'codecov'
     permissions:
       pull-requests: write
       issues: write
@@ -20,8 +24,7 @@ jobs:
             const owner = context.repo.owner;
             const repo  = context.repo.repo;
 
-            const run = context.payload.workflow_run;
-            const sha = run.head_sha;
+            const sha = context.payload.check_run.head_sha;
 
             const MARKER        = '<!-- pr-quality-bot -->';
             const CODECOV_START = '<!-- codecov-section-start -->';
@@ -71,8 +74,11 @@ jobs:
               CODECOV_CTXS.includes(c.name)
             );
 
-            if (!codecov.length) {
-              core.info('No Codecov check runs found yet');
+            const missing = CODECOV_CTXS.filter(
+              name => !codecov.find(c => c.name === name)
+            );
+            if (missing.length) {
+              core.info(`Still waiting on: ${missing.join(', ')}`);
               return;
             }
 

--- a/.github/workflows/pr-codecov-review.yml
+++ b/.github/workflows/pr-codecov-review.yml
@@ -74,30 +74,15 @@ jobs:
               CODECOV_CTXS.includes(c.name)
             );
 
-            const missing = CODECOV_CTXS.filter(
-              name => !codecov.find(c => c.name === name)
-            );
-            if (missing.length) {
-              core.info(`Still waiting on: ${missing.join(', ')}`);
-              return;
-            }
-
-            const pending = codecov.some(c => c.status !== 'completed');
-            if (pending) {
-              core.info('Codecov checks still running; will re-evaluate later.');
-              return;
-            }
-
-            // -- Build updated Codecov section --------------------------------
+            // Render each context independently instead of waiting for both:
+            // codecov/project can stay unavailable indefinitely on non-default
+            // branches, and blocking on it left the section stuck forever.
             const fmt = name => {
               const c = codecov.find(x => x.name === name);
-              if (!c) return `⚠️ \`${name}\``;
+              if (!c) return `⏳ \`${name}\` _(not yet reported)_`;
+              if (c.status !== 'completed') return `⏳ \`${name}\` _(running)_`;
 
-              const icon =
-                c.conclusion === 'success' ? '✅' :
-                c.conclusion === 'failure' ? '❌' :
-                '⏳';
-
+              const icon = c.conclusion === 'success' ? '✅' : '❌';
               return `${icon} \`${name}\``;
             };
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -167,6 +167,8 @@ jobs:
     if: always() && needs.detect.result == 'success'
     environment: codecov
     runs-on: ubuntu-latest
+    outputs:
+      ran: ${{ steps.tests.outputs.ran }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -200,8 +202,10 @@ jobs:
           crates=$(echo "$CRATES" | jq -r '.[]')
           if [[ -z "$crates" ]]; then
             echo "No changed crates detected, skipping."
+            echo "ran=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "ran=true" >> "$GITHUB_OUTPUT"
           # Build -p flags for tarpaulin
           pkg_args=""
           for crate in $crates; do
@@ -209,8 +213,12 @@ jobs:
           done
           cargo tarpaulin $pkg_args --out Lcov --output-dir ./coverage
 
+      # Only upload when tarpaulin actually ran: on the no-crates-changed skip
+      # path, no fresh lcov.info exists and codecov-action falls back to a
+      # stale target/tarpaulin/coverage.json restored from cache, which gets
+      # uploaded under the current commit's SHA with mismatched data.
       - name: Upload results to Codecov
-        if: always()
+        if: always() && steps.tests.outputs.ran == 'true'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -401,6 +409,7 @@ jobs:
         env:
           PULL_NUMBER: ${{ needs.resolve-inputs.outputs.pull_number }}
           COVERAGE_RESULT: ${{ needs.verify-code-coverage.result }}
+          COVERAGE_RAN: ${{ needs.verify-code-coverage.outputs.ran }}
           METADATA_RESULT: ${{ needs.verify-pr-metadata.result }}
         with:
           script: |
@@ -475,7 +484,12 @@ jobs:
               '## 📋 PR Metadata\n\n_Section unavailable — check [CI logs](' + runUrl + ')._';
 
             // -- Codecov placeholder ------------------------------------------
-            const codecovSection = [
+            // No changed crates means verify-code-coverage never ran tarpaulin
+            // or uploaded a report, so Codecov will never post check-runs for
+            // this commit — treat it as N/A instead of waiting forever.
+            const coverageRan = process.env.COVERAGE_RAN === 'true';
+
+            const codecovSection = coverageRan ? [
               CODECOV_START,
               '## 📊 Codecov',
               '',
@@ -488,6 +502,12 @@ jobs:
               '',
               '_Awaiting Codecov report..._',
               CODECOV_END,
+            ].join('\n') : [
+              CODECOV_START,
+              '## 📊 Codecov',
+              '',
+              '_No crates changed — coverage checks skipped for this PR._',
+              CODECOV_END,
             ].join('\n');
 
             // -- Overall header -----------------------------------------------
@@ -496,7 +516,7 @@ jobs:
               process.env.COVERAGE_RESULT === 'failure' ||
               process.env.METADATA_RESULT  === 'failure';
 
-            const headerIcon = hasNonCodecovErrors ? '❌' : '⏳';
+            const headerIcon = hasNonCodecovErrors ? '❌' : (coverageRan ? '⏳' : '✅');
 
             // -- Assemble full comment body ------------------------------------
             const body = [

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -398,6 +398,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+      checks: read
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -494,32 +495,69 @@ jobs:
             const coverageSkipped     = coverageJobOk && process.env.COVERAGE_RAN === 'false';
             const coverageUnavailable = !coverageJobOk;
 
-            const codecovSection = coveragePending ? [
-              CODECOV_START,
-              '## 📊 Codecov',
-              '',
-              '### Requirements',
-              '',
-              '⏳ `codecov/project`',
-              '⏳ `codecov/patch`',
-              '',
-              '### Errors',
-              '',
-              '_Awaiting Codecov report..._',
-              CODECOV_END,
-            ].join('\n') : coverageSkipped ? [
-              CODECOV_START,
-              '## 📊 Codecov',
-              '',
-              '_No crates changed — coverage checks skipped for this PR._',
-              CODECOV_END,
-            ].join('\n') : [
-              CODECOV_START,
-              '## 📊 Codecov',
-              '',
-              `_Coverage status unavailable — check [CI logs](${runUrl})._`,
-              CODECOV_END,
-            ].join('\n');
+            const CODECOV_CTXS = ['codecov/project', 'codecov/patch'];
+
+            let codecovSection;
+
+            if (coveragePending) {
+              // Codecov's check-runs post asynchronously after the upload
+              // finishes and can land before this job gets around to creating
+              // the comment. Query the live state here instead of always
+              // assuming pending: pr-codecov-review.yml only reacts to later
+              // check_run events, so a fast Codecov response would otherwise
+              // have nothing left to trigger the update and get stuck on
+              // "Awaiting Codecov report" forever.
+              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+              const { data: checks } = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref: pr.head.sha,
+              });
+              const codecov = checks.check_runs.filter(c => CODECOV_CTXS.includes(c.name));
+
+              const fmt = name => {
+                const c = codecov.find(x => x.name === name);
+                if (!c) return `⏳ \`${name}\` _(not yet reported)_`;
+                if (c.status !== 'completed') return `⏳ \`${name}\` _(running)_`;
+                return `${c.conclusion === 'success' ? '✅' : '❌'} \`${name}\``;
+              };
+
+              const errors = codecov
+                .filter(c => c.conclusion === 'failure')
+                .map(c => `- \`${c.name}\`: ${c.output?.summary || 'Failed'}`)
+                .join('\n');
+
+              codecovSection = [
+                CODECOV_START,
+                '## 📊 Codecov',
+                '',
+                '### Requirements',
+                '',
+                fmt('codecov/project'),
+                fmt('codecov/patch'),
+                '',
+                '### Errors',
+                '',
+                errors || '_No errors_',
+                CODECOV_END,
+              ].join('\n');
+            } else if (coverageSkipped) {
+              codecovSection = [
+                CODECOV_START,
+                '## 📊 Codecov',
+                '',
+                '_No crates changed — coverage checks skipped for this PR._',
+                CODECOV_END,
+              ].join('\n');
+            } else {
+              codecovSection = [
+                CODECOV_START,
+                '## 📊 Codecov',
+                '',
+                `_Coverage status unavailable — check [CI logs](${runUrl})._`,
+                CODECOV_END,
+              ].join('\n');
+            }
 
             // -- Overall header -----------------------------------------------
             const hasNonCodecovErrors =
@@ -527,7 +565,12 @@ jobs:
               coverageUnavailable ||
               process.env.METADATA_RESULT === 'failure';
 
-            const headerIcon = hasNonCodecovErrors ? '❌' : (coveragePending ? '⏳' : '✅');
+            const codecovStillPending = codecovSection.includes('⏳');
+            const codecovFailed       = codecovSection.includes('❌');
+
+            const headerIcon = (hasNonCodecovErrors || codecovFailed)
+              ? '❌'
+              : (codecovStillPending ? '⏳' : '✅');
 
             // -- Assemble full comment body ------------------------------------
             const body = [

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -218,7 +218,7 @@ jobs:
       # stale target/tarpaulin/coverage.json restored from cache, which gets
       # uploaded under the current commit's SHA with mismatched data.
       - name: Upload results to Codecov
-        if: always() && steps.tests.outputs.ran == 'true'
+        if: steps.tests.outcome == 'success' && steps.tests.outputs.ran == 'true'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -484,12 +484,17 @@ jobs:
               '## 📋 PR Metadata\n\n_Section unavailable — check [CI logs](' + runUrl + ')._';
 
             // -- Codecov placeholder ------------------------------------------
-            // No changed crates means verify-code-coverage never ran tarpaulin
-            // or uploaded a report, so Codecov will never post check-runs for
-            // this commit — treat it as N/A instead of waiting forever.
-            const coverageRan = process.env.COVERAGE_RAN === 'true';
+            // coverage.outputs.ran is only meaningful when the job itself
+            // completed successfully. If verify-code-coverage was skipped or
+            // failed upstream (e.g. needs.detect didn't succeed), `ran` is
+            // empty — don't mistake that for the legitimate "no crates
+            // changed" skip and render a false green status.
+            const coverageJobOk       = process.env.COVERAGE_RESULT === 'success';
+            const coveragePending     = coverageJobOk && process.env.COVERAGE_RAN === 'true';
+            const coverageSkipped     = coverageJobOk && process.env.COVERAGE_RAN === 'false';
+            const coverageUnavailable = !coverageJobOk;
 
-            const codecovSection = coverageRan ? [
+            const codecovSection = coveragePending ? [
               CODECOV_START,
               '## 📊 Codecov',
               '',
@@ -502,21 +507,27 @@ jobs:
               '',
               '_Awaiting Codecov report..._',
               CODECOV_END,
-            ].join('\n') : [
+            ].join('\n') : coverageSkipped ? [
               CODECOV_START,
               '## 📊 Codecov',
               '',
               '_No crates changed — coverage checks skipped for this PR._',
+              CODECOV_END,
+            ].join('\n') : [
+              CODECOV_START,
+              '## 📊 Codecov',
+              '',
+              `_Coverage status unavailable — check [CI logs](${runUrl})._`,
               CODECOV_END,
             ].join('\n');
 
             // -- Overall header -----------------------------------------------
             const hasNonCodecovErrors =
               guidelinesFailed ||
-              process.env.COVERAGE_RESULT === 'failure' ||
-              process.env.METADATA_RESULT  === 'failure';
+              coverageUnavailable ||
+              process.env.METADATA_RESULT === 'failure';
 
-            const headerIcon = hasNonCodecovErrors ? '❌' : (coverageRan ? '⏳' : '✅');
+            const headerIcon = hasNonCodecovErrors ? '❌' : (coveragePending ? '⏳' : '✅');
 
             // -- Assemble full comment body ------------------------------------
             const body = [


### PR DESCRIPTION
## What does this PR do?

Fixes the Codecov section of the PR-quality bot comment getting stuck at "Awaiting Codecov report..." forever, plus several related gaps found while validating the fix end-to-end against a live Codecov integration.

## Findings & Fixes

- **`workflow_run` raced Codecov's own async check-run posting.** Switched the trigger to `check_run: types: [completed]`, filtered to `github.event.check_run.app.slug == 'codecov'`. Note `workflow_run`/`check_run` triggers always resolve from the workflow file on the default branch regardless of which branch fired the event, so this only takes effect once merged here.
- **`codecov/project` can stay unavailable indefinitely on non-default branches**, even with a correct baseline already uploaded (confirmed live against a real Codecov integration) — waiting for both checks before ever touching the comment left it stuck forever. Each context now renders independently as soon as its own check-run completes.
- **A stale cached coverage file could get uploaded under the wrong commit.** When no crate changed, tarpaulin never ran, but the upload step still fired unconditionally and Codecov's auto-discovery fell back to a leftover `target/tarpaulin/coverage.json` restored from cache. Upload is now gated on the tests step having actually run and succeeded.
- **A `verify-code-coverage` job skipped upstream (e.g. `detect` failing) rendered a false-green "no crates changed" status**, because an empty `ran` output was indistinguishable from the intentional skip case. The two are now told apart using the job's own `result`.
- **The comment can be created after Codecov already reported, with no later event left to fix it** — Codecov never re-fires a completed check-run, so if it posts before `post-review` creates the comment, `pr-codecov-review.yml` finds nothing to update. `post-review` now queries live check-run state at comment-creation time instead of always writing a static pending placeholder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request coverage reporting with clearer pending, running, successful, and failed statuses.
  * Coverage results now update against the correct commit, keeping indicators and review comments accurate.
  * Pull requests with no applicable changes now show coverage as skipped instead of pending.
  * Prevented outdated or premature coverage updates while checks are still processing.
  * Coverage sections now distinguish between skipped, unavailable, and not-yet-reported results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
