### PR TITLE
backport: codecov-review fix into trunk

### DIFF
--- a/.github/workflows/pr-codecov-review.yml
+++ b/.github/workflows/pr-codecov-review.yml
@@ -1,13 +1,22 @@
 name: Update PR Codecov Review
 
 on:
-  workflow_run:
-    workflows: ["pr-validator"]
+  check_run:
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        description: "PR number to refresh the Codecov section for"
+        required: true
+
+concurrency:
+  group: codecov-review-${{ github.event.check_run.head_sha || github.event.inputs.pull_number }}
 
 jobs:
   update-codecov-section:
     runs-on: ubuntu-latest
+    # check_run has no trigger-level filter, so restrict to Codecov's own app here.
+    if: github.event_name == 'workflow_dispatch' || github.event.check_run.app.slug == 'codecov'
     permissions:
       pull-requests: write
       issues: write
@@ -15,34 +24,47 @@ jobs:
     steps:
       - name: Update Codecov section and post indicator review
         uses: actions/github-script@v9
+        env:
+          INPUT_PULL_NUMBER: ${{ github.event.inputs.pull_number }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo  = context.repo.repo;
-
-            const run = context.payload.workflow_run;
-            const sha = run.head_sha;
 
             const MARKER        = '<!-- pr-quality-bot -->';
             const CODECOV_START = '<!-- codecov-section-start -->';
             const CODECOV_END   = '<!-- codecov-section-end -->';
             const CODECOV_CTXS  = ['codecov/project', 'codecov/patch'];
 
-            // -- Find the open PR for this SHA ---------------------------------
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner,
-              repo,
-              commit_sha: sha,
-            });
+            // -- Resolve the target PR and commit SHA --------------------------
+            // workflow_dispatch already names the PR directly; check_run only
+            // gives us a commit, so look up which open PR it belongs to.
+            let sha;
+            let pull_number;
 
-            const pr = prs.find(p => p.state === 'open');
+            if (context.eventName === 'workflow_dispatch') {
+              pull_number = parseInt(process.env.INPUT_PULL_NUMBER, 10);
 
-            if (!pr) {
-              core.info(`No open PR for SHA ${sha}`);
-              return;
+              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+              sha = pr.head.sha;
+            } else {
+              sha = context.payload.check_run.head_sha;
+
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: sha,
+              });
+
+              const pr = prs.find(p => p.state === 'open');
+
+              if (!pr) {
+                core.info(`No open PR for SHA ${sha}`);
+                return;
+              }
+
+              pull_number = pr.number;
             }
-
-            const pull_number = pr.number;
 
             // -- Find the comment ---------------------------------------
             const { data: comments } = await github.rest.issues.listComments({
@@ -71,27 +93,15 @@ jobs:
               CODECOV_CTXS.includes(c.name)
             );
 
-            if (!codecov.length) {
-              core.info('No Codecov check runs found yet');
-              return;
-            }
-
-            const pending = codecov.some(c => c.status !== 'completed');
-            if (pending) {
-              core.info('Codecov checks still running; will re-evaluate later.');
-              return;
-            }
-
-            // -- Build updated Codecov section --------------------------------
+            // Render each context independently instead of waiting for both:
+            // codecov/project can stay unavailable indefinitely on non-default
+            // branches, and blocking on it left the section stuck forever.
             const fmt = name => {
               const c = codecov.find(x => x.name === name);
-              if (!c) return `⚠️ \`${name}\``;
+              if (!c) return `⏳ \`${name}\` _(not yet reported)_`;
+              if (c.status !== 'completed') return `⏳ \`${name}\` _(running)_`;
 
-              const icon =
-                c.conclusion === 'success' ? '✅' :
-                c.conclusion === 'failure' ? '❌' :
-                '⏳';
-
+              const icon = c.conclusion === 'success' ? '✅' : '❌';
               return `${icon} \`${name}\``;
             };
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -167,6 +167,8 @@ jobs:
     if: always() && needs.detect.result == 'success'
     environment: codecov
     runs-on: ubuntu-latest
+    outputs:
+      ran: ${{ steps.tests.outputs.ran }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -200,8 +202,10 @@ jobs:
           crates=$(echo "$CRATES" | jq -r '.[]')
           if [[ -z "$crates" ]]; then
             echo "No changed crates detected, skipping."
+            echo "ran=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "ran=true" >> "$GITHUB_OUTPUT"
           # Build -p flags for tarpaulin
           pkg_args=""
           for crate in $crates; do
@@ -209,8 +213,12 @@ jobs:
           done
           cargo tarpaulin $pkg_args --out Lcov --output-dir ./coverage
 
+      # Only upload when tarpaulin actually ran: on the no-crates-changed skip
+      # path, no fresh lcov.info exists and codecov-action falls back to a
+      # stale target/tarpaulin/coverage.json restored from cache, which gets
+      # uploaded under the current commit's SHA with mismatched data.
       - name: Upload results to Codecov
-        if: always()
+        if: steps.tests.outcome == 'success' && steps.tests.outputs.ran == 'true'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -390,6 +398,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+      checks: read
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -401,6 +410,7 @@ jobs:
         env:
           PULL_NUMBER: ${{ needs.resolve-inputs.outputs.pull_number }}
           COVERAGE_RESULT: ${{ needs.verify-code-coverage.result }}
+          COVERAGE_RAN: ${{ needs.verify-code-coverage.outputs.ran }}
           METADATA_RESULT: ${{ needs.verify-pr-metadata.result }}
         with:
           script: |
@@ -475,28 +485,92 @@ jobs:
               '## 📋 PR Metadata\n\n_Section unavailable — check [CI logs](' + runUrl + ')._';
 
             // -- Codecov placeholder ------------------------------------------
-            const codecovSection = [
-              CODECOV_START,
-              '## 📊 Codecov',
-              '',
-              '### Requirements',
-              '',
-              '⏳ `codecov/project`',
-              '⏳ `codecov/patch`',
-              '',
-              '### Errors',
-              '',
-              '_Awaiting Codecov report..._',
-              CODECOV_END,
-            ].join('\n');
+            // coverage.outputs.ran is only meaningful when the job itself
+            // completed successfully. If verify-code-coverage was skipped or
+            // failed upstream (e.g. needs.detect didn't succeed), `ran` is
+            // empty — don't mistake that for the legitimate "no crates
+            // changed" skip and render a false green status.
+            const coverageJobOk       = process.env.COVERAGE_RESULT === 'success';
+            const coveragePending     = coverageJobOk && process.env.COVERAGE_RAN === 'true';
+            const coverageSkipped     = coverageJobOk && process.env.COVERAGE_RAN === 'false';
+            const coverageUnavailable = !coverageJobOk;
+
+            const CODECOV_CTXS = ['codecov/project', 'codecov/patch'];
+
+            let codecovSection;
+
+            if (coveragePending) {
+              // Codecov's check-runs post asynchronously after the upload
+              // finishes and can land before this job gets around to creating
+              // the comment. Query the live state here instead of always
+              // assuming pending: pr-codecov-review.yml only reacts to later
+              // check_run events, so a fast Codecov response would otherwise
+              // have nothing left to trigger the update and get stuck on
+              // "Awaiting Codecov report" forever.
+              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+              const { data: checks } = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref: pr.head.sha,
+              });
+              const codecov = checks.check_runs.filter(c => CODECOV_CTXS.includes(c.name));
+
+              const fmt = name => {
+                const c = codecov.find(x => x.name === name);
+                if (!c) return `⏳ \`${name}\` _(not yet reported)_`;
+                if (c.status !== 'completed') return `⏳ \`${name}\` _(running)_`;
+                return `${c.conclusion === 'success' ? '✅' : '❌'} \`${name}\``;
+              };
+
+              const errors = codecov
+                .filter(c => c.conclusion === 'failure')
+                .map(c => `- \`${c.name}\`: ${c.output?.summary || 'Failed'}`)
+                .join('\n');
+
+              codecovSection = [
+                CODECOV_START,
+                '## 📊 Codecov',
+                '',
+                '### Requirements',
+                '',
+                fmt('codecov/project'),
+                fmt('codecov/patch'),
+                '',
+                '### Errors',
+                '',
+                errors || '_No errors_',
+                CODECOV_END,
+              ].join('\n');
+            } else if (coverageSkipped) {
+              codecovSection = [
+                CODECOV_START,
+                '## 📊 Codecov',
+                '',
+                '_No crates changed — coverage checks skipped for this PR._',
+                CODECOV_END,
+              ].join('\n');
+            } else {
+              codecovSection = [
+                CODECOV_START,
+                '## 📊 Codecov',
+                '',
+                `_Coverage status unavailable — check [CI logs](${runUrl})._`,
+                CODECOV_END,
+              ].join('\n');
+            }
 
             // -- Overall header -----------------------------------------------
             const hasNonCodecovErrors =
               guidelinesFailed ||
-              process.env.COVERAGE_RESULT === 'failure' ||
-              process.env.METADATA_RESULT  === 'failure';
+              coverageUnavailable ||
+              process.env.METADATA_RESULT === 'failure';
 
-            const headerIcon = hasNonCodecovErrors ? '❌' : '⏳';
+            const codecovStillPending = codecovSection.includes('⏳');
+            const codecovFailed       = codecovSection.includes('❌');
+
+            const headerIcon = (hasNonCodecovErrors || codecovFailed)
+              ? '❌'
+              : (codecovStillPending ? '⏳' : '✅');
 
             // -- Assemble full comment body ------------------------------------
             const body = [


### PR DESCRIPTION
## Summary

Backports #167 (`main` only, since changes there don't flow back to `dev/trunk` automatically): fixes the PR-quality bot's Codecov section getting stuck at "Awaiting Codecov report..." forever, plus the related gaps found while validating it end-to-end, and adds a `workflow_dispatch` input to manually refresh a given PR's Codecov section on demand.

## Related issue

Closes #

## Reviewer focus

Single clean commit, no conflicts with `dev/trunk`'s own history (verified via `git merge-tree`) — only touches `.github/workflows/pr.yaml` and `.github/workflows/pr-codecov-review.yml`, neither modified by `dev/trunk`'s own commits since the last backport.

## Pre-merge checklist

- [x] PR title follows the squash-merge commit title
- [x] Missing coverage of the new change is explained in reviewer focus
- [x] Public API changes (if any) are noted in the summary above
- [x] The linked story/task is updated if scope has shifted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request coverage reporting with clearer states for pending, successful, failed, unavailable, or skipped test coverage.
  - Coverage results now update progressively as checks complete instead of blocking when information is temporarily unavailable.
  - Overall review status now accurately reflects coverage failures and cases where coverage could not run.

- **New Features**
  - Added support for manually refreshing coverage review results for a pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->