### PR TITLE
event: add a display method to print the name of the modifiers

### DIFF
--- a/crates/cargo-extract/src/main.rs
+++ b/crates/cargo-extract/src/main.rs
@@ -13,8 +13,7 @@ use guppy::{
 fn main() -> Result<()> {
     // Get the --since argument from the command line
     let since = env::args().nth(1).context(
-        "Usage: cargo run -p cargo-extract -- <since_commit_or_tag>\n   or: \
-         cargo-extract <since_commit_or_tag>",
+        "Usage: cargo run -p cargo-extract -- <since_commit_or_tag>\n   or: cargo-extract <since_commit_or_tag>",
     )?;
 
     // Run `cargo workspaces changed --since <since>`
@@ -25,18 +24,11 @@ fn main() -> Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!(
-            "cargo workspaces changed failed ({}): {}",
-            output.status,
-            stderr
-        );
+        anyhow::bail!("cargo workspaces changed failed ({}): {}", output.status, stderr);
     }
 
     let changed_stdout = String::from_utf8(output.stdout)?;
-    let changed: HashSet<String> = changed_stdout
-        .split_whitespace()
-        .map(|s| s.to_string())
-        .collect();
+    let changed: HashSet<String> = changed_stdout.split_whitespace().map(|s| s.to_string()).collect();
 
     if changed.is_empty() {
         return Ok(());
@@ -49,15 +41,10 @@ fn main() -> Result<()> {
 
     if !metadata_output.status.success() {
         let stderr = String::from_utf8_lossy(&metadata_output.stderr);
-        anyhow::bail!(
-            "cargo metadata failed ({}): {}",
-            metadata_output.status,
-            stderr
-        );
+        anyhow::bail!("cargo metadata failed ({}): {}", metadata_output.status, stderr);
     }
 
-    let metadata =
-        CargoMetadata::parse_json(&String::from_utf8(metadata_output.stdout)?)?;
+    let metadata = CargoMetadata::parse_json(&String::from_utf8(metadata_output.stdout)?)?;
 
     let graph = PackageGraph::from_metadata(metadata)?;
 
@@ -79,8 +66,7 @@ fn main() -> Result<()> {
             continue;
         }
 
-        let reverse =
-            graph.query_reverse(std::slice::from_ref(pkg_id))?.resolve();
+        let reverse = graph.query_reverse(std::slice::from_ref(pkg_id))?.resolve();
 
         for pkg in reverse.packages(Reverse) {
             let name = pkg.name().to_string();

--- a/crates/termoxide_event/src/event.rs
+++ b/crates/termoxide_event/src/event.rs
@@ -8,7 +8,10 @@
 //! lets the framework swap or support several backends without touching
 //! consumer code.
 
-use std::ops::{BitOr, BitOrAssign};
+use std::{
+    fmt,
+    ops::{BitOr, BitOrAssign},
+};
 
 /// A single keyboard key, independent of the terminal backend.
 ///
@@ -76,7 +79,7 @@ pub enum KeyCode {
 /// assert!(!combo.contains(KeyModifiers::ALT));
 /// assert!(KeyModifiers::NONE.is_empty());
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct KeyModifiers(u8);
 
 impl KeyModifiers {
@@ -109,6 +112,51 @@ impl BitOr for KeyModifiers {
 
 impl BitOrAssign for KeyModifiers {
     fn bitor_assign(&mut self, rhs: Self) { self.0 |= rhs.0; }
+}
+
+impl fmt::Display for KeyModifiers {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_empty() {
+            return f.write_str("none");
+        }
+
+        let entries = [
+            (Self::SHIFT, "shift"),
+            (Self::CONTROL, "control"),
+            (Self::ALT, "alt"),
+            (Self::SUPER, "super"),
+        ];
+
+        let mut wrote_any = false;
+        let known_bits = Self::SHIFT.0 | Self::CONTROL.0 | Self::ALT.0 | Self::SUPER.0;
+        for (flag, label) in entries {
+            if self.contains(flag) {
+                if wrote_any {
+                    f.write_str("+")?;
+                }
+                f.write_str(label)?;
+                wrote_any = true;
+            }
+        }
+
+        let unknown_bits = self.0 & !known_bits;
+        if unknown_bits != 0 {
+            if wrote_any {
+                f.write_str("+")?;
+            }
+            write!(f, "unknown({})", unknown_bits)?;
+            wrote_any = true;
+        }
+        if !wrote_any {
+            return write!(f, "unknown({})", self.0);
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Debug for KeyModifiers {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Display::fmt(self, f) }
 }
 
 /// A single key press: which key, and which modifiers were held with it.
@@ -144,4 +192,34 @@ pub enum Event {
     /// A key was pressed. Only key *presses* are reported — releases and
     /// repeats are filtered out by the backend.
     KeyPress(KeyEvent),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::KeyModifiers;
+
+    #[test]
+    fn key_modifiers_display_uses_readable_names() {
+        assert_eq!(format!("{}", KeyModifiers::NONE), "none");
+        assert_eq!(format!("{}", KeyModifiers::CONTROL), "control");
+        assert_eq!(format!("{}", KeyModifiers::CONTROL | KeyModifiers::SHIFT), "shift+control");
+    }
+
+    #[test]
+    fn key_modifiers_debug_matches_display() {
+        let combo = KeyModifiers::CONTROL | KeyModifiers::ALT;
+        assert_eq!(format!("{combo}"), format!("{combo:?}"));
+    }
+
+    #[test]
+    fn key_modifiers_display_shows_unknown_bits() {
+        let mods = KeyModifiers(1 << 4);
+        assert_eq!(format!("{mods}"), "unknown(16)");
+    }
+
+    #[test]
+    fn key_modifiers_display_shows_known_and_unknown_bits() {
+        let mods = KeyModifiers(KeyModifiers::CONTROL.0 | (1 << 4));
+        assert_eq!(format!("{mods}"), "control+unknown(16)");
+    }
 }


### PR DESCRIPTION
<!-- TermOxide PR — internal default

     This template is for the original team during the concept phase.

     Keep this PR small and focused. If you're tempted to add a long
     description, consider whether the work should have been split. -->

## Summary

<!-- One or two sentences. What does this PR do and why? -->
This PR add a method to print the name of the modifiers. I use it at first for the demo but can be usefull later.

## Related issue

<!-- Use "Closes #123" to auto-close on merge. Use "Part of #123" if
     this is one of several PRs landing the same story. -->

Closes #

## Reviewer focus

<!-- Optional. Anything tricky, uncertain, or that you want a second
     pair of eyes on. Leave empty if the PR is self-explanatory. -->

## Pre-merge checklist

- [ ] PR title follows the squash-merge commit title
- [ ] Missing coverage of the new change is explained in reviewer focus
- [ ] Public API changes (if any) are noted in the summary above
- [ ] The linked story/task is updated if scope has shifted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard modifier output with clearer names for known, absent, combined, and unrecognized modifiers.
  * Clarified error messages and metadata-related output in the package analysis tool without changing its behavior.

* **Tests**
  * Added coverage to verify consistent Debug and Display formatting for keyboard modifiers, including combined and unknown values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->